### PR TITLE
Foldable summary functions

### DIFF
--- a/Numeric/Units/Dimensional/DK.hs
+++ b/Numeric/Units/Dimensional/DK.hs
@@ -416,9 +416,7 @@ The arithmetic mean of all elements in a list.
 mean :: forall a d f.(Fractional a, Foldable f) => f (Quantity d a) -> Quantity d a
 mean = div . foldr f (_0 :: Quantity d a, 0 :: Int)
      where
-       f :: Quantity d a -> (Quantity d a, Int) -> (Quantity d a, Int)
        f val (accum, count) = (accum + val, count Prelude.+ 1)
-       div :: (Quantity d a, Int) -> Quantity d a
        div (Dimensional accum, count) = Dimensional (accum Prelude./ (Prelude.fromIntegral count))
 
 {-


### PR DESCRIPTION
I suggest changing the sum function for quantities to be defined in terms of `Foldable` instead of `[]`.

I also suggest adding a `mean` function. The proposed implementation is a little bit confusing, but it does only do one fold. I'm not sure whether some dark magic would optimize the conceptually simpler definition in terms of `sum` and `dimensionlessLength`, and I don't know how to check.
