### PR TITLE
Term level dimensions

### DIFF
--- a/Numeric/Units/Dimensional/DK.hs
+++ b/Numeric/Units/Dimensional/DK.hs
@@ -573,10 +573,11 @@ instance ( ToInteger (NT l)
          , Show a) =>
   Show (Quantity (Dim l m t i th n j) a)
     where
-      show (Dimensional x) = let dims = asList $ toSIBasis (Proxy :: Proxy (Dim l m t i th n j))
+      show (Dimensional x) = let powers = asList $ toSIBasis (Proxy :: Proxy (Dim l m t i th n j))
                                  units = ["m", "kg", "s", "A", "K", "mol", "cd"]
-                                 powers = zipWith dimUnit units dims
-                             in unwords (show x : catMaybes powers)
+                                 dims = zipWith dimUnit units powers
+                                 unit = unwords $ ("" : catMaybes dims)
+                             in (show x) ++ unit
 
 {-
 The above implementation of 'show' relies on the dimension 'd' being an


### PR DESCRIPTION
Following up on #5, here's a stab at converting type-level `Dimension`s to term-level `Dimension'`s.

By way of illustration, I also converted the `Show` instance for dimensional values to use `Dimension'` as the first step of the conversion.

The performance should be similar. But it should also only be necessary to perform the whole reflection dance once per dimension, so it shouldn't be crucial either way.
