### PR TITLE
Explicit exports

### DIFF
--- a/Numeric/Units/Dimensional/DK.hs
+++ b/Numeric/Units/Dimensional/DK.hs
@@ -71,7 +71,6 @@ and implementation.
 -}
 
 module Numeric.Units.Dimensional.DK
-      -- TODO discriminate exports, in particular Variants and Dims.
   ( (^), (^+), (^/), (**), (*), (/), (+), (-), (*~), (/~),
     Dimensional(..), -- constructor to be hidden in future refactoring?
     Variant(..), Unit, Quantity, Dimension(..),


### PR DESCRIPTION
Created an explicit export list for the main DK module. This helps by hiding some helper functions.

It raises the question of whether to export the `Dimensional` constructor of `Dimensional`. I would strongly favor not exporting it to prevent shenanigans, but the current implementation has the benefit of allowing the `meter` etc. to be defined in the `SIUnits` module instead of in the main module.

It is possible to get the best of both worlds by making an `Internal` submodule.
