### PR TITLE
Made the Dimension' constructor strict in all its fields

### DIFF
--- a/Numeric/Units/Dimensional/DK.hs
+++ b/Numeric/Units/Dimensional/DK.hs
@@ -560,7 +560,7 @@ At the term level, Dimension' encodes a dimension as 7 integers, representing a 
 
 -}
 
-data Dimension' = Dim' Int Int Int Int Int Int Int deriving (Show,Eq,Ord)
+data Dimension' = Dim' !Int !Int !Int !Int !Int !Int !Int deriving (Show,Eq,Ord)
 
 class KnownDimension (d::Dimension) where toSIBasis :: Proxy d -> Dimension'
 instance ( ToInteger (NT l)


### PR DESCRIPTION
There's no point to laziness here. If we know the dimension we know all of these `Int`s, and we're almost certain to want all of them if we want any of them.
