### PR TITLE
Removed the Enum instance for Dimensional.

### DIFF
--- a/Numeric/Units/Dimensional/DK.hs
+++ b/Numeric/Units/Dimensional/DK.hs
@@ -52,7 +52,6 @@ Clients probably will want to use the NegativeLiterals extension.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -87,7 +86,7 @@ module Numeric.Units.Dimensional.DK
   where
 
 import Prelude
-  ( Show, Eq, Ord, Enum, Num, Fractional, Floating, RealFloat, Functor, fmap
+  ( Show, Eq, Ord, Num, Fractional, Floating, RealFloat, Functor, fmap
   , (.), flip, show, (++), undefined, otherwise, (==), String, unwords
   , map, null, Integer, Int, ($), zipWith, uncurry
   )
@@ -131,7 +130,7 @@ units and quantities it represents have physical dimensions.
 -}
 
 newtype Dimensional (v::Variant) (d::Dimension) a
-      = Dimensional a deriving (Eq, Ord, Enum)
+      = Dimensional a deriving (Eq, Ord)
 
 {-
 The type variable 'a' is the only non-phantom type variable and


### PR DESCRIPTION
It seems like the `Enum` instance needlessly exposes the implementation details of `Dimensional`, because there is no physical reason why `succ (1 *~ meter)` should be 2 meters, while `succ (1 *~ foot)` is 1.3048 meters.

Perhaps some analog of `enumFromTo` that increments by a specified quantity might better suit any existing clients? Or `[0..1000] *~~ meter`?
