### PR TITLE
Generalized types for commonly convenient folds

### DIFF
--- a/Numeric/Units/Dimensional/DK/Prelude.hs
+++ b/Numeric/Units/Dimensional/DK/Prelude.hs
@@ -21,12 +21,12 @@ import Numeric.NumType.DK
     )  -- Used in exponents.
 
 import Data.Foldable
-    ( minimum, maximum )
+    ( product, minimum, maximum )
 
 import Prelude hiding
     ( (+), (-), (*), (/), (^), (**)
     , abs, negate, pi, exp, log, sqrt
     , sin, cos, tan, asin, acos, atan, atan2
     , sinh, cosh, tanh, asinh, acosh, atanh
-    , sum, minimum, maximum
+    , sum, product, minimum, maximum
     )  -- Hide definitions overridden by 'Numeric.Dimensional'.


### PR DESCRIPTION
I changed the prelude to export `product`, `minimum`, and `maximum` from `Data.Foldable` instead of from `Prelude`.

This shouldn't hurt anyone because it's in the `base` package, and so is the `Foldable` instance for `[]`. It also matches what we did with `sum`.
