### PR TITLE
Added ~/ operator as a companion to *~. Generalized *~.

### DIFF
--- a/Numeric/Units/Dimensional/DK.hs
+++ b/Numeric/Units/Dimensional/DK.hs
@@ -71,7 +71,7 @@ and implementation.
 -}
 
 module Numeric.Units.Dimensional.DK
-  ( (^), (^/), (**), (*), (/), (+), (-), (*~), (/~),
+  ( (^), (^/), (**), (*), (/), (+), (-), (*~), (~/), (/~),
     Dimensional,
     Unit, Quantity, Dimension (Dim),
     DOne, DLength, DMass, DTime, DElectricCurrent, DThermodynamicTemperature, DAmountOfSubstance, DLuminousIntensity,
@@ -168,8 +168,11 @@ number and a 'Unit'. We define the '(*~)' operator as a convenient
 way to declare quantities as such a product.
 -}
 
-(*~) :: Num a => a -> Unit d a -> Quantity d a
+(*~) :: Num a => a -> Dimensional v d a -> Quantity d a
 x *~ Dimensional y = Dimensional (x Prelude.* y)
+
+(~/) :: Fractional a => Dimensional v d a -> a -> Quantity d a
+(~/) = flip $ (*~) . Prelude.recip
 
 {-
 Conversely, the numerical value of a 'Quantity' is obtained by
@@ -187,7 +190,7 @@ Note that this necessitates the use of parenthesis when composing
 units using '*' and '/', e.g. "1 *~ (meter / second)".
 -}
 
-infixl 7  *~, /~
+infixl 7  *~, /~, ~/
 
 {-
 


### PR DESCRIPTION
For concreteness, here's an implementation of what I was talking about in #37.

```
Numeric.Units.Dimensional.DK.Prelude> :set -XNoImplicitPrelude
Numeric.Units.Dimensional.DK.Prelude> :m Numeric.Units.Dimensional.DK.Prelude
Numeric.Units.Dimensional.DK.Prelude> let areaOfCircle r = pi * r^pos2 ~/ 2
Numeric.Units.Dimensional.DK.Prelude> let r = 13.7 *~ meter
Numeric.Units.Dimensional.DK.Prelude> areaOfCircle r
294.8227625761341 m^2
```
