### PR TITLE
Explicitly derive Typeable.

### DIFF
--- a/Numeric/Units/Dimensional/DK.hs
+++ b/Numeric/Units/Dimensional/DK.hs
@@ -104,6 +104,7 @@ import qualified Numeric.NumType.DK as N
 import Data.Proxy (Proxy(..))
 import Data.Foldable (Foldable(foldr, foldl'))
 import Data.Monoid (Monoid(..))
+import Data.Typeable
 
 {-
 We will reuse the operators and function names from the Prelude.
@@ -132,7 +133,7 @@ units and quantities it represents have physical dimensions.
 -}
 
 newtype Dimensional (v::Variant) (d::Dimension) a
-      = Dimensional a deriving (Eq, Ord, Enum)
+      = Dimensional a deriving (Eq, Ord, Enum, Typeable)
 
 {-
 The type variable 'a' is the only non-phantom type variable and


### PR DESCRIPTION
For some reason (GHC bug? there are several on trac that seem like they might apply, but they all seem fixed and I can't tell if this is an exact match), `AutoDeriveTypeable` doesn't automatically derive `Typeable` for `Dimensional` for me on 7.8 rc1.
