### PR TITLE
Storable and Data.Vector.Unboxed.Unbox instances for Quantities

### DIFF
--- a/dimensional-dk.cabal
+++ b/dimensional-dk.cabal
@@ -1,5 +1,5 @@
 name:                dimensional-dk
-version:             0.8.0.1
+version:             0.8.0.2
 license:             BSD3
 license-file:        LICENSE
 copyright:           Bjorn Buckwalter 2006-2015
@@ -38,6 +38,10 @@ source-repository head
   type:     git
   location: https://github.com/bjornbm/dimensional-dk/
 
+flag vector
+  description: Enable `vector` instances.
+  default: False
+
 library
   build-depends:       base >= 4.7 && < 5,
                        numtype-dk >= 0.5 && < 1.1
@@ -53,6 +57,9 @@ library
                        Numeric.Units.Dimensional.DK.Dimensions.TermLevel,
                        Numeric.Units.Dimensional.DK.Dimensions.TypeLevel,
                        Numeric.Units.Dimensional.DK.Functor
+  if flag(vector)
+    build-depends:     vector
+    cpp-options:       -DVECTOR
 
 test-suite tests
   type:                exitcode-stdio-1.0

--- a/dimensional-dk.cabal
+++ b/dimensional-dk.cabal
@@ -58,7 +58,7 @@ library
                        Numeric.Units.Dimensional.DK.Dimensions.TypeLevel,
                        Numeric.Units.Dimensional.DK.Functor
   if flag(vector)
-    build-depends:     vector
+    build-depends:     vector >= 0.10
     cpp-options:       -DVECTOR
 
 test-suite tests

--- a/src/Numeric/Units/Dimensional/DK.hs
+++ b/src/Numeric/Units/Dimensional/DK.hs
@@ -750,32 +750,32 @@ newtype instance U.MVector s (Quantity d a) = MV_Quantity {unMVQ :: U.MVector s 
 instance U.Unbox a => U.Unbox (Quantity d a)
 
 instance (M.MVector U.MVector a) => M.MVector U.MVector (Quantity d a) where
-  {-# INLINE basicLength #-}
-  {-# INLINE basicUnsafeSlice #-}
-  {-# INLINE basicOverlaps #-}
-  {-# INLINE basicUnsafeNew #-}
-  {-# INLINE basicUnsafeRead #-}
-  {-# INLINE basicUnsafeWrite #-}
   basicLength          = M.basicLength . unMVQ
+  {-# INLINE basicLength #-}
   basicUnsafeSlice m n = MV_Quantity . M.basicUnsafeSlice m n . unMVQ
+  {-# INLINE basicUnsafeSlice #-}
   basicOverlaps u v    = M.basicOverlaps (unMVQ u) (unMVQ v)
+  {-# INLINE basicOverlaps #-}
   basicUnsafeNew       = fmap MV_Quantity . M.basicUnsafeNew
+  {-# INLINE basicUnsafeNew #-}
   basicUnsafeRead v    = fmap coerce . M.basicUnsafeRead (unMVQ v)
+  {-# INLINE basicUnsafeRead #-}
   basicUnsafeWrite v i = M.basicUnsafeWrite (unMVQ v) i . coerce
+  {-# INLINE basicUnsafeWrite #-}
 #if MIN_VERSION_vector(0,11,0)
   basicInitialize      = M.basicInitialize . unMVQ
   {-# INLINE basicInitialize #-}
 #endif
 
 instance (G.Vector U.Vector a) => G.Vector U.Vector (Quantity d a) where
-  {-# INLINE basicUnsafeFreeze #-}
-  {-# INLINE basicUnsafeThaw #-}
-  {-# INLINE basicLength #-}
-  {-# INLINE basicUnsafeSlice #-}
-  {-# INLINE basicUnsafeIndexM #-}
   basicUnsafeFreeze    = fmap V_Quantity  . G.basicUnsafeFreeze . unMVQ
+  {-# INLINE basicUnsafeFreeze #-}
   basicUnsafeThaw      = fmap MV_Quantity . G.basicUnsafeThaw   . unVQ
+  {-# INLINE basicUnsafeThaw #-}
   basicLength          = G.basicLength . unVQ
+  {-# INLINE basicLength #-}
   basicUnsafeSlice m n = V_Quantity . G.basicUnsafeSlice m n . unVQ
+  {-# INLINE basicUnsafeSlice #-}
   basicUnsafeIndexM v  = fmap coerce . G.basicUnsafeIndexM (unVQ v)
+  {-# INLINE basicUnsafeIndexM #-}
 #endif


### PR DESCRIPTION
This PR adds `Storable` and `Unbox`instances for `Quantity` so they can be used efficiently in arrays. The vector instances are enabled with a flag to avoid paying for the extra dependency if not used (although I would rather have them enabled by default since vector is a pretty standard package)
