### PR TITLE
Rename repository from dimensional-dk to dimensional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This library provides statically-checked dimensional arithmetic for physical qua
 Data kinds and closed type families provide a flexible, safe, and discoverable implementation that leads to largely self-documenting
 client code.
 
-[![Build Status](https://travis-ci.org/bjornbm/dimensional-dk.svg?branch=master)](https://travis-ci.org/bjornbm/dimensional-dk)
+[![Build Status](https://travis-ci.org/bjornbm/dimensional.svg?branch=master)](https://travis-ci.org/bjornbm/dimensional)
 [![Hackage Version](http://img.shields.io/hackage/v/dimensional.svg)](http://hackage.haskell.org/package/dimensional)
 
 ## Usage
@@ -47,4 +47,4 @@ differenceFromStandardValue = approximateAccelerationDueToGravityOnEarth /~ gee
 ## Contributing
 
 For project information (issues, updates, wiki, examples) see:
-  https://github.com/bjornbm/dimensional-dk
+  https://github.com/bjornbm/dimensional

--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -6,7 +6,7 @@ copyright:           Bjorn Buckwalter 2006-2015
 author:              Bjorn Buckwalter
 maintainer:          bjorn@buckwalter.se
 stability:           experimental
-homepage:            https://github.com/bjornbm/dimensional-dk/
+homepage:            https://github.com/bjornbm/dimensional/
 category:            Math, Physics
 synopsis:            Statically checked physical dimensions,
                      using Type Families and Data Kinds.
@@ -38,7 +38,7 @@ extra-source-files:  README.md,
 
 source-repository head
   type:     git
-  location: https://github.com/bjornbm/dimensional-dk/
+  location: https://github.com/bjornbm/dimensional/
 
 library
   build-depends:       base >= 4.7 && < 5,


### PR DESCRIPTION
These are the source-level changes required to rename the repository. The actual renaming operation can only be performed by the owner. The github docs indicate that they will automatically host a page redirecting the old name to the new one as long as the owner doesn't reuse the old name.

If you elect to merge this then I will push a new release to hackage so that the updated links make it there asap.
