### PR TITLE
Added package flags for optional instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS --dry -v > installplan.txt
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --flags=$FLAGS --dry -v > installplan.txt
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
@@ -87,7 +87,7 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks --flags $FLAGS -v  # -v provides useful information for debugging
+ - cabal configure --enable-tests --enable-benchmarks --flags=$FLAGS -v  # -v provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test --show-details=always
  - cabal haddock

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
 # This line does all of the work: build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
-script: stack $ARGS $FLAGS --no-terminal test --haddock --bench
+script: stack $ARGS --no-terminal test $FLAGS --haddock --bench
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks --flags=$FLAGS;
    fi
 
 # snapshot package-db on cache miss

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,28 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="functor"
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="aeson"
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="binary"
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="cereal"
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="linear"
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="vector-space"
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="functor aeson binary cereal linear vector-space"
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
 
@@ -37,7 +55,7 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS --dry -v > installplan.txt
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
@@ -67,7 +85,7 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal configure --enable-tests --enable-benchmarks --flags $FLAGS -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test --show-details=always
  - cabal haddock

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS --allow-newer=binary;
    fi
 
 # snapshot package-db on cache miss

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
     - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="functor aeson binary cereal linear vector-space"
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+  allow_failures:
+    - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="functor aeson binary cereal linear vector-space"
 
 before_install:
  - unset CC
@@ -55,7 +57,7 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS --allow-newer=binary --dry -v > installplan.txt
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS --dry -v > installplan.txt
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
@@ -69,7 +71,7 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS --allow-newer=binary;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS;
    fi
 
 # snapshot package-db on cache miss

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ env:
 - ARGS="--resolver lts-2 --stack-yaml stack.lts2.yaml"
 - ARGS="--resolver lts-3"
 - ARGS="--resolver lts"
-- ARGS="--resolver lts --flag dimensional:aeson"
-- ARGS="--resolver lts --flag dimensional:binary"
-- ARGS="--resolver lts --flag dimensional:cereal"
-- ARGS="--resolver lts --flag dimensional:vector-space"
-- ARGS="--resolver lts --flag dimensional:aeson --flag dimensional:binary --flag dimensional:cereal --flag dimensional:vector-space"
+- ARGS="--resolver lts" FLAGS="--flag dimensional:aeson"
+- ARGS="--resolver lts" FLAGS="--flag dimensional:binary"
+- ARGS="--resolver lts" FLAGS="--flag dimensional:cereal"
+- ARGS="--resolver lts" FLAGS="--flag dimensional:vector-space"
+- ARGS="--resolver lts" FLAGS="--flag dimensional:aeson --flag dimensional:binary --flag dimensional:cereal --flag dimensional:vector-space"
 - ARGS="--resolver nightly"
 
 before_install:
@@ -40,7 +40,7 @@ before_install:
 # This line does all of the work: build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
-script: stack $ARGS --no-terminal test --haddock --bench
+script: stack $ARGS $FLAGS --no-terminal test --haddock --bench
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.18 GHCVER=7.8.4
+    - env: CABALVER=1.18 GHCVER=7.8.4 FLAGS=""
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3
+    - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS=""
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3 FLAGS="functor"
@@ -55,7 +55,7 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS --dry -v > installplan.txt
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --flags $FLAGS --allow-newer=binary --dry -v > installplan.txt
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
@@ -85,7 +85,7 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks --flags $FLAGS -v2  # -v2 provides useful information for debugging
+ - cabal configure --enable-tests --enable-benchmarks --flags $FLAGS -v  # -v provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test --show-details=always
  - cabal haddock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ vNext
   module which may cause name collisions.
 * Breaking: Removed exports of `nMeter`, `nSecond`, `kilo`, etc from Numeric.Units.Dimensional.UnitNames.
   Access these instead by inspecting the relevant units or prefixes.
+* Deprecated: The `Numeric.Units.Dimensional.Functor` module and the orphan instance
+  it provides were deprecated in favor of a package flag, `functor`, which provides the
+  same instance but doesn't orphan it.
+* Added package flags `aeson`, `binary`, `cereal`, `linear`, and `vector-space` enabling
+  optional dependencies on the packages of the same names to provide instances of widely
+  used classes from those packages.
 * Added `Data`, `Generic`, `Typeable` and `NFData` instances for many ancillary types.
 * Added `unQuantity` to the Coercion module to ease unwrapping without
   introducing ambiguous type variables.

--- a/README.md
+++ b/README.md
@@ -68,16 +68,11 @@ main = do
 Package flags are available which enable us to provide instances for Quantity that are useful to interoperate with various popular packages without burdening all users with those
 dependencies or creating orphan instances.
 
-To install with a `Functor` instance for quantities of all dimensions, instead of just
-for dimensionless quantities, use:
-
-`cabal install dimensional -f functor`
-
 To install with `ToJSON` and `FromJSON` instances for `Quantity`, use:
 
 `cabal install dimensional -f aeson`
 
-Similarly the `binary`, `cereal`, `linear`, and `vector-space` flags enable appropriate
+Similarly the `binary`, `cereal`, and `vector-space` flags enable appropriate
 instances for use with the packages of the same names.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ main = do
          putStrLn $ "The journey requires " ++ show wholeSeconds ++ " seconds, rounded up to the nearest second."
 ```
 
+## Package Flags
+
+Package flags are available which enable us to provide instances for Quantity that are useful to interoperate with various popular packages without burdening all users with those
+dependencies or creating orphan instances.
+
+To install with a `Functor` instance for quantities of all dimensions, instead of just
+for dimensionless quantities, use:
+
+`cabal install dimensional -f functor`
+
+To install with `ToJSON` and `FromJSON` instances for `Quantity`, use:
+
+`cabal install dimensional -f aeson`
+
+Similarly the `binary`, `cereal`, `linear`, and `vector-space` flags enable appropriate
+instances for use with the packages of the same names.
+
 ## Contributing
 
 For project information (issues, updates, wiki, examples) see:

--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -36,6 +36,36 @@ extra-source-files:  README.md,
                      examples/README,
                      examples/GM.lhs
 
+flag functor
+  description: Provide a Functor instance for Quantity.
+  default:     False
+  manual:      True
+
+flag aeson
+  description: Provide instances for use with the aeson package.
+  default:     False
+  manual:      True
+
+flag binary
+  description: Provide instances for use with the binary package.
+  default:     False
+  manual:      True
+
+flag cereal
+  description: Provide instances for use with the cereal package.
+  default:     False
+  manual:      True
+
+flag linear
+  description: Provide instances for use with the linear package.
+  default:     False
+  manual:      True
+
+flag vector-space
+  description: Provide instances for use with the vector-space package.
+  default:     False
+  manual:      True
+
 source-repository head
   type:     git
   location: https://github.com/bjornbm/dimensional/
@@ -65,6 +95,29 @@ library
                        Numeric.Units.Dimensional.Variants
   other-modules:       Numeric.Units.Dimensional.Internal,
                        Numeric.Units.Dimensional.UnitNames.Internal
+
+  if flag(functor)
+    cpp-options:       -DFUNCTOR
+
+  if flag(aeson)
+    build-depends:     aeson >= 0.10 && < 1
+    cpp-options:       -DUSE_AESON
+
+  if flag(binary)
+    build-depends:     binary >= 0.7 && < 1
+    cpp-options:       -DUSE_BINARY
+
+  if flag(cereal)
+    build-depends:     cereal >= 0.5 && <1
+    cpp-options:       -DUSE_CEREAL
+
+  if flag(linear)
+    build-depends:     linear >= 1.19 && < 2
+    cpp-options:       -DUSE_LINEAR
+
+  if flag(vector-space)
+    build-depends:     vector-space >= 0.10 && < 1
+    cpp-options:       -DUSE_VECTOR_SPACE
 
 test-suite tests
   type:                exitcode-stdio-1.0

--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -89,7 +89,7 @@ library
                        Numeric.Units.Dimensional.UnitNames.Internal
 
   if flag(aeson)
-    build-depends:     aeson >= 0.10 && < 1
+    build-depends:     aeson >= 0.9 && < 1
     cpp-options:       -DUSE_AESON
 
   if flag(binary)

--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -37,11 +37,6 @@ extra-source-files:  README.md,
                      examples/ReadmeExample.hs,
                      examples/GM.lhs
 
-flag functor
-  description: Provide a Functor instance for Quantity.
-  default:     False
-  manual:      True
-
 flag aeson
   description: Provide instances for use with the aeson package.
   default:     False
@@ -54,11 +49,6 @@ flag binary
 
 flag cereal
   description: Provide instances for use with the cereal package.
-  default:     False
-  manual:      True
-
-flag linear
-  description: Provide instances for use with the linear package.
   default:     False
   manual:      True
 
@@ -98,9 +88,6 @@ library
   other-modules:       Numeric.Units.Dimensional.Internal,
                        Numeric.Units.Dimensional.UnitNames.Internal
 
-  if flag(functor)
-    cpp-options:       -DFUNCTOR
-
   if flag(aeson)
     build-depends:     aeson >= 0.10 && < 1
     cpp-options:       -DUSE_AESON
@@ -112,10 +99,6 @@ library
   if flag(cereal)
     build-depends:     cereal >= 0.5 && <1
     cpp-options:       -DUSE_CEREAL
-
-  if flag(linear)
-    build-depends:     linear >= 1.19 && < 2
-    cpp-options:       -DUSE_LINEAR
 
   if flag(vector-space)
     build-depends:     vector-space >= 0.10 && < 1

--- a/src/Numeric/Units/Dimensional.hs
+++ b/src/Numeric/Units/Dimensional.hs
@@ -640,7 +640,8 @@ tau = _2 * pi
 We intentionally decline to provide a 'Functor' instance for 'Dimensional' because its use breaks the
 abstraction of physical dimensions.
 
-If you feel your work requires this instance, it is provided as an orphan in "Numeric.Units.Dimensional.Functor".
+If you feel your work requires this instance, it is provided by enabling the `functor` package
+flag when installing the package.
 
 -}
 

--- a/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
@@ -1,9 +1,12 @@
 {-# OPTIONS_HADDOCK not-home, show-extensions #-}
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 {- |
    Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
@@ -40,6 +43,17 @@ import GHC.Generics
 import Prelude (id, (+), (-), (.), Int, Show, Eq, Ord, Maybe(..))
 import qualified Prelude as P
 
+-- Optional imports when certain package flags are enabled
+#if USE_AESON
+import qualified Data.Aeson
+#endif
+#if USE_BINARY
+import qualified Data.Binary
+#endif
+#if USE_CEREAL
+import qualified Data.Serialize
+#endif
+
 -- | A physical dimension, encoded as 7 integers, representing a factorization of the dimension into the
 -- 7 SI base dimensions. By convention they are stored in the same order as 
 -- in the 'Numeric.Units.Dimensional.Dimensions.TypeLevel.Dimension' data kind.
@@ -53,6 +67,20 @@ instance NFData Dimension' where
 instance Monoid Dimension' where
   mempty = dOne
   mappend = (*)
+
+#if USE_AESON
+deriving instance Data.Aeson.ToJSON Dimension'
+
+deriving instance Data.Aeson.FromJSON Dimension'
+#endif
+
+#if USE_BINARY
+deriving instance Data.Binary.Binary Dimension'
+#endif
+
+#if USE_CEREAL
+deriving instance Data.Serialize.Serialize Dimension'
+#endif
 
 -- | Dimensional values, or those that are only possibly dimensional, inhabit this class,
 -- which allows access to a term-level representation of their dimension.

--- a/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
@@ -3,10 +3,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 {- |
    Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
@@ -69,17 +67,21 @@ instance Monoid Dimension' where
   mappend = (*)
 
 #if USE_AESON
-deriving instance Data.Aeson.ToJSON Dimension'
+-- This instance only needs a body because an incorrect MINIMAL pragma in aeson-0.10 leads to
+-- a warning if you omit it.
+instance Data.Aeson.ToJSON Dimension' where
+  toJSON = Data.Aeson.genericToJSON Data.Aeson.defaultOptions
+  toEncoding = Data.Aeson.genericToEncoding Data.Aeson.defaultOptions
 
-deriving instance Data.Aeson.FromJSON Dimension'
+instance Data.Aeson.FromJSON Dimension'
 #endif
 
 #if USE_BINARY
-deriving instance Data.Binary.Binary Dimension'
+instance Data.Binary.Binary Dimension'
 #endif
 
 #if USE_CEREAL
-deriving instance Data.Serialize.Serialize Dimension'
+instance Data.Serialize.Serialize Dimension'
 #endif
 
 -- | Dimensional values, or those that are only possibly dimensional, inhabit this class,

--- a/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
@@ -44,6 +44,7 @@ import qualified Prelude as P
 -- Optional imports when certain package flags are enabled
 #if USE_AESON
 import qualified Data.Aeson
+import qualified Data.Aeson.Types
 #endif
 #if USE_BINARY
 import qualified Data.Binary
@@ -76,8 +77,7 @@ instance Monoid Dimension' where
 -- This instance only needs a body because an incorrect MINIMAL pragma in aeson-0.10 leads to
 -- a warning if you omit it.
 instance Data.Aeson.ToJSON Dimension' where
-  toJSON = Data.Aeson.genericToJSON Data.Aeson.defaultOptions
-  toEncoding = Data.Aeson.genericToEncoding Data.Aeson.defaultOptions
+  toJSON = Data.Aeson.genericToJSON Data.Aeson.Types.defaultOptions
 
 instance Data.Aeson.FromJSON Dimension'
 #endif

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -58,6 +58,7 @@ import qualified Numeric.Units.Dimensional.Dimensions.TermLevel as D
 -- Optional imports when certain package flags are enabled
 #if USE_AESON
 import qualified Data.Aeson
+import qualified Data.Aeson.Types
 import qualified Data.Monoid
 #endif
 #if USE_BINARY
@@ -137,7 +138,6 @@ instance Num a => Monoid (AnyQuantity a) where
 #if USE_AESON
 instance (Data.Aeson.ToJSON a) => Data.Aeson.ToJSON (AnyQuantity a) where
   toJSON (AnyQuantity d a) = Data.Aeson.object ["dimension" Data.Aeson..= d, "value" Data.Aeson..= a]
-  toEncoding (AnyQuantity d a) = Data.Aeson.pairs ("dimension" Data.Aeson..= d Data.Monoid.<> "value" Data.Aeson..= a)
 
 instance (Data.Aeson.FromJSON a) => Data.Aeson.FromJSON (AnyQuantity a) where
   parseJSON (Data.Aeson.Object v) = AnyQuantity P.<$>
@@ -216,8 +216,7 @@ instance Num a => Monoid (DynQuantity a) where
 -- This instance only needs a body because an incorrect MINIMAL pragma in aeson-0.10 leads to
 -- a warning if you omit it.
 instance (Data.Aeson.ToJSON a) => Data.Aeson.ToJSON (DynQuantity a) where
-  toJSON = Data.Aeson.genericToJSON Data.Aeson.defaultOptions
-  toEncoding = Data.Aeson.genericToEncoding Data.Aeson.defaultOptions
+  toJSON = Data.Aeson.genericToJSON Data.Aeson.Types.defaultOptions
 
 instance (Data.Aeson.FromJSON a) => Data.Aeson.FromJSON (DynQuantity a)
 #endif

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -11,7 +11,6 @@ Defines types for manipulation of units and quantities without phantom types for
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -20,7 +19,6 @@ Defines types for manipulation of units and quantities without phantom types for
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Numeric.Units.Dimensional.Dynamic
 (
@@ -149,11 +147,11 @@ instance (Data.Aeson.FromJSON a) => Data.Aeson.FromJSON (AnyQuantity a) where
 #endif
 
 #if USE_BINARY
-deriving instance (Data.Binary.Binary a) => Data.Binary.Binary (AnyQuantity a)
+instance (Data.Binary.Binary a) => Data.Binary.Binary (AnyQuantity a)
 #endif
 
 #if USE_CEREAL
-deriving instance (Data.Serialize.Serialize a) => Data.Serialize.Serialize (AnyQuantity a)
+instance (Data.Serialize.Serialize a) => Data.Serialize.Serialize (AnyQuantity a)
 #endif
 
 -- | Possibly a 'Quantity' whose 'Dimension' is only known dynamically.
@@ -224,17 +222,19 @@ instance Num a => Monoid (DynQuantity a) where
   mappend = (P.*)
 
 #if USE_AESON
-deriving instance (Data.Aeson.ToJSON a) => Data.Aeson.ToJSON (DynQuantity a)
+instance (Data.Aeson.ToJSON a) => Data.Aeson.ToJSON (DynQuantity a) where
+  toJSON = Data.Aeson.genericToJSON Data.Aeson.defaultOptions
+  toEncoding = Data.Aeson.genericToEncoding Data.Aeson.defaultOptions
 
-deriving instance (Data.Aeson.FromJSON a) => Data.Aeson.FromJSON (DynQuantity a)
+instance (Data.Aeson.FromJSON a) => Data.Aeson.FromJSON (DynQuantity a)
 #endif
 
 #if USE_BINARY
-deriving instance (Data.Binary.Binary a) => Data.Binary.Binary (DynQuantity a)
+instance (Data.Binary.Binary a) => Data.Binary.Binary (DynQuantity a)
 #endif
 
 #if USE_CEREAL
-deriving instance (Data.Serialize.Serialize a) => Data.Serialize.Serialize (DynQuantity a)
+instance (Data.Serialize.Serialize a) => Data.Serialize.Serialize (DynQuantity a)
 #endif
 
 -- Lifts a function which is only valid on dimensionless quantities into a function on DynQuantitys.

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -9,14 +9,18 @@
 Defines types for manipulation of units and quantities without phantom types for their dimensions.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Numeric.Units.Dimensional.Dynamic
 (
@@ -52,6 +56,18 @@ import qualified Numeric.Units.Dimensional.UnitNames.InterchangeNames as I
 import qualified Numeric.Units.Dimensional.UnitNames as N
 import Numeric.Units.Dimensional.Dimensions.TermLevel (HasDynamicDimension(..))
 import qualified Numeric.Units.Dimensional.Dimensions.TermLevel as D
+
+-- Optional imports when certain package flags are enabled
+#if USE_AESON
+import qualified Data.Aeson
+import qualified Data.Monoid
+#endif
+#if USE_BINARY
+import qualified Data.Binary
+#endif
+#if USE_CEREAL
+import qualified Data.Serialize
+#endif
 
 -- | The class of types that can be used to model 'Quantity's that are certain to have a value with
 -- some dimension.
@@ -120,6 +136,25 @@ instance Num a => Monoid (AnyQuantity a) where
   mempty = demoteQuantity (1 Dim.*~ one)
   mappend (AnyQuantity d1 a1) (AnyQuantity d2 a2) = AnyQuantity (d1 D.* d2) (a1 P.* a2)
 
+#if USE_AESON
+instance (Data.Aeson.ToJSON a) => Data.Aeson.ToJSON (AnyQuantity a) where
+  toJSON (AnyQuantity d a) = Data.Aeson.object ["dimension" Data.Aeson..= d, "value" Data.Aeson..= a]
+  toEncoding (AnyQuantity d a) = Data.Aeson.pairs ("dimension" Data.Aeson..= d Data.Monoid.<> "value" Data.Aeson..= a)
+
+instance (Data.Aeson.FromJSON a) => Data.Aeson.FromJSON (AnyQuantity a) where
+  parseJSON (Data.Aeson.Object v) = AnyQuantity P.<$>
+                                    v Data.Aeson..: "dimension" P.<*>
+                                    v Data.Aeson..: "value"
+  parseJSON _ = Data.Monoid.mempty
+#endif
+
+#if USE_BINARY
+deriving instance (Data.Binary.Binary a) => Data.Binary.Binary (AnyQuantity a)
+#endif
+
+#if USE_CEREAL
+deriving instance (Data.Serialize.Serialize a) => Data.Serialize.Serialize (AnyQuantity a)
+#endif
 
 -- | Possibly a 'Quantity' whose 'Dimension' is only known dynamically.
 --
@@ -187,6 +222,20 @@ instance Floating a => Floating (DynQuantity a) where
 instance Num a => Monoid (DynQuantity a) where
   mempty = demoteQuantity (1 Dim.*~ one)
   mappend = (P.*)
+
+#if USE_AESON
+deriving instance (Data.Aeson.ToJSON a) => Data.Aeson.ToJSON (DynQuantity a)
+
+deriving instance (Data.Aeson.FromJSON a) => Data.Aeson.FromJSON (DynQuantity a)
+#endif
+
+#if USE_BINARY
+deriving instance (Data.Binary.Binary a) => Data.Binary.Binary (DynQuantity a)
+#endif
+
+#if USE_CEREAL
+deriving instance (Data.Serialize.Serialize a) => Data.Serialize.Serialize (DynQuantity a)
+#endif
 
 -- Lifts a function which is only valid on dimensionless quantities into a function on DynQuantitys.
 liftDimensionless :: (a -> a) -> DynQuantity a -> DynQuantity a

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -222,6 +222,8 @@ instance Num a => Monoid (DynQuantity a) where
   mappend = (P.*)
 
 #if USE_AESON
+-- This instance only needs a body because an incorrect MINIMAL pragma in aeson-0.10 leads to
+-- a warning if you omit it.
 instance (Data.Aeson.ToJSON a) => Data.Aeson.ToJSON (DynQuantity a) where
   toJSON = Data.Aeson.genericToJSON Data.Aeson.defaultOptions
   toEncoding = Data.Aeson.genericToEncoding Data.Aeson.defaultOptions

--- a/src/Numeric/Units/Dimensional/Functor.hs
+++ b/src/Numeric/Units/Dimensional/Functor.hs
@@ -25,8 +25,10 @@ Note that, while this instance overlaps with that given for 'Dimensionless', it 
 
 Note that this is an orphan instance.
 -}
-module Numeric.Units.Dimensional.Functor where
+module Numeric.Units.Dimensional.Functor {-# DEPRECATED "This orphan instance is being eliminated in favor of a package flag, functor, which creates it as a proper instance." #-} where
 
+-- If we already have this instance, we won't declare it again.
+#if !(FUNCTOR || USE_LINEAR)
 import Numeric.Units.Dimensional
 
 -- | A 'Functor' instance for 'Dimensional'.
@@ -38,3 +40,4 @@ import Numeric.Units.Dimensional
 -- Note that this is an orphan instance.
 instance {-# OVERLAPPING #-} (KnownVariant v) => Functor (Dimensional v d) where
   fmap = dmap
+#endif

--- a/src/Numeric/Units/Dimensional/Functor.hs
+++ b/src/Numeric/Units/Dimensional/Functor.hs
@@ -25,7 +25,7 @@ Note that, while this instance overlaps with that given for 'Dimensionless', it 
 
 Note that this is an orphan instance.
 -}
-module Numeric.Units.Dimensional.Functor {-# DEPRECATED "This orphan instance is being eliminated in favor of a package flag, functor, which creates it as a proper instance." #-} where
+module Numeric.Units.Dimensional.Functor {-# DEPRECATED "This orphan instance is being eliminated, along with the module packaging it, in favor of a package flag, functor, which creates it as a proper instance." #-} where
 
 -- If we already have this instance, we won't declare it again.
 #if !(FUNCTOR || USE_LINEAR)

--- a/src/Numeric/Units/Dimensional/Functor.hs
+++ b/src/Numeric/Units/Dimensional/Functor.hs
@@ -25,10 +25,8 @@ Note that, while this instance overlaps with that given for 'Dimensionless', it 
 
 Note that this is an orphan instance.
 -}
-module Numeric.Units.Dimensional.Functor {-# DEPRECATED "This orphan instance is being eliminated, along with the module packaging it, in favor of a package flag, functor, which creates it as a proper instance." #-} where
+module Numeric.Units.Dimensional.Functor where
 
--- If we already have this instance, we won't declare it again.
-#if !(FUNCTOR || USE_LINEAR)
 import Numeric.Units.Dimensional
 
 -- | A 'Functor' instance for 'Dimensional'.
@@ -40,4 +38,3 @@ import Numeric.Units.Dimensional
 -- Note that this is an orphan instance.
 instance {-# OVERLAPPING #-} (KnownVariant v) => Functor (Dimensional v d) where
   fmap = dmap
-#endif

--- a/src/Numeric/Units/Dimensional/Internal.hs
+++ b/src/Numeric/Units/Dimensional/Internal.hs
@@ -62,11 +62,6 @@ import qualified Data.Binary
 #if USE_CEREAL
 import qualified Data.Serialize
 #endif
-#if USE_LINEAR
-import qualified Linear.Affine
-import qualified Linear.Metric
-import qualified Linear.Vector
-#endif
 #if USE_VECTOR_SPACE
 import qualified Data.AdditiveGroup
 import qualified Data.VectorSpace
@@ -121,19 +116,8 @@ instance (Typeable m) => KnownVariant ('DUnit m) where
   injectValue _        _ = error "Shouldn't be reachable. Needed to name a quantity."
   dmap f (Unit n e x) = Unit n e (f x)
 
-{-
-
-If the FUNCTOR flag is set or is required by another flag, we provide a Functor instance for all dimensional values.
-Regardless, we provide a functor instance for dimensionless quantities.
-
--}
-#if FUNCTOR || USE_LINEAR
-instance (KnownVariant v) => Functor (Dimensional v d) where
-  fmap = dmap
-#else
 instance Functor (Quantity DOne) where
   fmap = dmap
-#endif
 
 #if USE_AESON
 deriving instance (Data.Aeson.ToJSON a) => Data.Aeson.ToJSON (Quantity d a)
@@ -147,25 +131,6 @@ deriving instance (Data.Binary.Binary a) => Data.Binary.Binary (Quantity d a)
 
 #if USE_CEREAL
 deriving instance (Data.Serialize.Serialize a) => Data.Serialize.Serialize (Quantity d a)
-#endif
-
-#if USE_LINEAR
-instance Linear.Vector.Additive (Quantity d) where
-  zero = mempty
-  (^+^) = liftQ2 (P.+)
-  (^-^) = liftQ2 (P.-)
-  liftU2 = liftQ2
-  liftI2 f (Quantity x) (Quantity y) = Quantity $ f x y
-
-instance Linear.Metric.Metric (Quantity DOne) where
-  dot (Quantity x) (Quantity y) = x P.* y
-  norm (Quantity x) = P.abs x
-
-instance Linear.Affine.Affine (Quantity d) where
-  type Diff (Quantity d) = Quantity d
-  (.-.) = (Linear.Vector.^-^)
-  (.+^) = (Linear.Vector.^+^)
-  (.-^) = (Linear.Vector.^-^)
 #endif
 
 #if USE_VECTOR_SPACE

--- a/src/Numeric/Units/Dimensional/Internal.hs
+++ b/src/Numeric/Units/Dimensional/Internal.hs
@@ -64,6 +64,7 @@ import qualified Data.Serialize
 #endif
 #if USE_LINEAR
 import qualified Linear.Affine
+import qualified Linear.Metric
 import qualified Linear.Vector
 #endif
 #if USE_VECTOR_SPACE
@@ -155,6 +156,10 @@ instance Linear.Vector.Additive (Quantity d) where
   (^-^) = liftQ2 (P.-)
   liftU2 = liftQ2
   liftI2 f (Quantity x) (Quantity y) = Quantity $ f x y
+
+instance Linear.Metric.Metric (Quantity DOne) where
+  dot (Quantity x) (Quantity y) = x P.* y
+  norm (Quantity x) = P.abs x
 
 instance Linear.Affine.Affine (Quantity d) where
   type Diff (Quantity d) = Quantity d

--- a/src/Numeric/Units/Dimensional/Internal.hs
+++ b/src/Numeric/Units/Dimensional/Internal.hs
@@ -135,6 +135,9 @@ instance Functor (Quantity DOne) where
 #endif
 
 #if USE_AESON
+deriving instance (Data.Aeson.ToJSON a) => Data.Aeson.ToJSON (Quantity d a)
+
+deriving instance (Data.Aeson.FromJSON a) => Data.Aeson.FromJSON (Quantity d a)
 #endif
 
 #if USE_BINARY

--- a/src/Numeric/Units/Dimensional/Internal.hs
+++ b/src/Numeric/Units/Dimensional/Internal.hs
@@ -149,6 +149,18 @@ deriving instance (Data.Serialize.Serialize a) => Data.Serialize.Serialize (Quan
 #endif
 
 #if USE_LINEAR
+instance Linear.Vector.Additive (Quantity d) where
+  zero = mempty
+  (^+^) = liftQ2 (P.+)
+  (^-^) = liftQ2 (P.-)
+  liftU2 = liftQ2
+  liftI2 f (Quantity x) (Quantity y) = Quantity $ f x y
+
+instance Linear.Affine.Affine (Quantity d) where
+  type Diff (Quantity d) = Quantity d
+  (.-.) = (Linear.Vector.^-^)
+  (.+^) = (Linear.Vector.^+^)
+  (.-^) = (Linear.Vector.^-^)
 #endif
 
 #if USE_VECTOR_SPACE


### PR DESCRIPTION
As the next step in the tentative plan at #95 on how to deal with various desirable instances which aren't worth the dependencies they would incur to all users, I've prepared this sketch of how it will work.

Comments are welcome on whether this is the right road or not.

It's not ready yet for a few reasons:
- <strike>Documentation in the readme</strike>
- <strike>Instances for the `linear` package</strike>
- <strike>Instances for the `aeson` package</strike>
- <strike>Instances for the serialization classes for various ancillary types</strike>
- Changes to the travis build to add the following flavors (only against the latest GHC, to avoid creating an enormous matrix)
  - <strike>With no flags</strike>
  - <strike>With each flag alone</strike>
  - <strike>With all flags</strike>
