### PR TITLE
Simplify DynQuantity

### DIFF
--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -38,7 +38,7 @@ import Data.Data
 import Data.ExactPi
 import Data.Monoid (Monoid(..))
 import GHC.Generics
-import Prelude (Eq(..), Num, Fractional, Floating(..), Show(..), Maybe(..), (.), ($), (>>=), (&&), (++), all, const, div, error, even, fmap, otherwise, return)
+import Prelude (Eq(..), Num, Fractional, Floating, Show(..), Maybe(..), (.), ($), (>>=), (&&), (++), all, const, div, error, even, fmap, otherwise, return)
 import qualified Prelude as P
 import Numeric.Units.Dimensional hiding ((*), (/), (^), recip)
 import Numeric.Units.Dimensional.Coercion
@@ -129,7 +129,7 @@ instance Fractional a => Fractional (DynQuantity a) where
   fromRational = demoteQuantity . (*~ one) . P.fromRational
 
 instance Floating a => Floating (DynQuantity a) where
-  pi = demoteQuantity $ P.pi *~ one
+  pi = demoteQuantity pi
   exp = liftDimensionless P.exp
   log = liftDimensionless P.log
   sqrt = liftDQ div2 (P.sqrt)

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -38,7 +38,7 @@ import Data.Data
 import Data.ExactPi
 import Data.Monoid (Monoid(..))
 import GHC.Generics
-import Prelude (Eq(..), Num, Fractional, Floating(..), Show(..), Maybe(..), (.), ($), (&&), (++), all, const, div, error, even, fmap, otherwise, return)
+import Prelude (Eq(..), Num, Fractional, Floating(..), Show(..), Maybe(..), (.), ($), (>>=), (&&), (++), all, const, div, error, even, fmap, otherwise, return)
 import qualified Prelude as P
 import Numeric.Units.Dimensional hiding ((*), (/), (^), recip)
 import Numeric.Units.Dimensional.Coercion
@@ -109,12 +109,10 @@ instance NFData a => NFData (DynQuantity a) -- instance is derived from Generic 
 
 instance DynamicQuantity DynQuantity where
   demoteQuantity = DynQuantity . Just . demoteQuantity
-  promoteQuantity (DynQuantity (Just x)) = promoteQuantity x
-  promoteQuantity _                      = Nothing
+  promoteQuantity (DynQuantity q) = q >>= promoteQuantity
 
 instance HasDynamicDimension (DynQuantity a) where
-  dynamicDimension (DynQuantity (Just x)) = dynamicDimension x
-  dynamicDimension _                      = Nothing
+  dynamicDimension (DynQuantity q) = q >>= dynamicDimension
 
 instance Num a => Num (DynQuantity a) where
   (+) = liftDQ2 matching (P.+)

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -183,24 +183,24 @@ liftDimensionless = liftDQ (matching D.dOne)
 liftDQ :: (Dimension' -> Maybe Dimension')
        -> (a -> a)
        -> DynQuantity a -> DynQuantity a
-liftDQ fd fv = coerce $ liftDQ'
+liftDQ fd fv = coerce f
   where
-    liftDQ' q = do
-                  (AnyQuantity d v) <- q
-                  d' <- fd d
-                  return $ AnyQuantity d' (fv v)
+    f q = do
+            (AnyQuantity d v) <- q
+            d' <- fd d
+            return $ AnyQuantity d' (fv v)
 
 -- Lifts a function on values into a function on DynQuantitys.
 liftDQ2 :: (Dimension' -> Dimension' -> Maybe Dimension')
         -> (a -> a -> a)
         -> DynQuantity a -> DynQuantity a -> DynQuantity a
-liftDQ2 fd fv = coerce $ liftDQ2'
+liftDQ2 fd fv = coerce f
   where
-    liftDQ2' q1 q2 = do
-                       (AnyQuantity d1 v1) <- q1
-                       (AnyQuantity d2 v2) <- q2
-                       d' <- fd d1 d2
-                       return $ AnyQuantity d' (fv v1 v2)
+    f q1 q2 = do
+                (AnyQuantity d1 v1) <- q1
+                (AnyQuantity d2 v2) <- q2
+                d' <- fd d1 d2
+                return $ AnyQuantity d' (fv v1 v2)
 
 -- | A 'Unit' whose 'Dimension' is only known dynamically.
 data AnyUnit = AnyUnit Dimension' (UnitName 'NonMetric) ExactPi


### PR DESCRIPTION
Simplify the operations that lift into `DynQuantity` by capitalizing on the `Monad` instance for `Maybe`.
Counter-proposal to #117.
