### PR TITLE
Changes to documentation and term-level for negative roots

### DIFF
--- a/src/Numeric/Units/Dimensional.hs
+++ b/src/Numeric/Units/Dimensional.hs
@@ -464,6 +464,8 @@ for units as well as quantities.
 -- are supplied by the "Numeric.NumType.DK.Integers" module. The most commonly used ones are
 -- also reexported by "Numeric.Units.Dimensional.Prelude".
 --
+-- n must not be zero. Negative roots are defined such that @nroot (Proxy :: Proxy (Negate n)) x == nroot (Proxy :: Proxy n) (recip x)@.
+--
 -- Also available in operator form, see '^/'.
 nroot :: (KnownTypeInt n, Floating a)
       => Proxy n -> Quantity d a -> Quantity (Root d n) a

--- a/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
@@ -115,9 +115,11 @@ recip = (dOne /)
 
 -- | Takes the nth root of a dimension, if it exists.
 --
--- n must be positive.
+-- n must not be zero.
+--
+-- prop> nroot (negate n) d == nroot n (recip d)
 nroot :: Int -> Dimension' -> Maybe Dimension'
-nroot n d | n > 0 && all ((== 0) . snd) ds = fromList . fmap fst $ ds
+nroot n d | n /= 0 && all ((== 0) . snd) ds = fromList . fmap fst $ ds
           | otherwise                      = Nothing
   where
     ds = fmap (`divMod` n) . asList $ d


### PR DESCRIPTION
Add documentation clarifying the meaning of negative roots.
Allow term-level negative roots.
Resolves issues discussed in #132 and #133.
