### PR TITLE
Documentation examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ vNext
   `(Num a, Foldable f) => f (Dimensional v d a) -> Dimensionless a)` to
   `(Num a, Foldable f) => f b -> Dimensionless a`. This provides a weaker constraint on the type `a`
   and may result in ambiguous types in code that depends on the former less general type.
+* Fixed a bug in the definition of the `inHg_NIST`.
+* Added units for the US survey foot, yard, inch, mil, and mile.
+* Clarified that the UCUM acre is based on the US survey foot.
+* Added a version of the acre based on the international foot.
 * Added `Data`, `Generic`, `Typeable` and `NFData` instances for many ancillary types.
 * Added `unQuantity` to the Coercion module to ease unwrapping without
   introducing ambiguous type variables.

--- a/src/Numeric/Units/Dimensional.hs
+++ b/src/Numeric/Units/Dimensional.hs
@@ -398,6 +398,9 @@ Multiplication, division and powers apply to both units and quantities.
 (/) = liftD2 (Prelude./) (Prelude./) (Name./)
 
 -- | Forms the reciprocal of a 'Quantity', which has the reciprocal dimension.
+--
+-- >>> recip $ 47 *~ hertz
+-- 2.127659574468085e-2 s
 recip :: (Fractional a) => Quantity d a -> Quantity (Recip d) a
 recip = liftQ Prelude.recip
 

--- a/src/Numeric/Units/Dimensional.hs
+++ b/src/Numeric/Units/Dimensional.hs
@@ -614,11 +614,26 @@ atanh = fmap Prelude.atanh
 (**) = liftQ2 (Prelude.**)
 
 -- | Takes the logarithm of the second argument in the base of the first.
+--
+-- >>> logBase _2 _8
+-- 3.0
 logBase :: Floating a => Dimensionless a -> Dimensionless a -> Dimensionless a
 logBase = liftQ2 Prelude.logBase
 
 -- | The standard two argument arctangent function.
 -- Since it interprets its two arguments in comparison with one another, the input may have any dimension.
+--
+-- >>> atan2 _0 _1
+-- 0.0
+--
+-- >>> atan2 _1 _0
+-- 1.5707963267948966
+--
+-- >>> atan2 _0 (negate _1)
+-- 3.141592653589793
+--
+-- >>> atan2 (negate _1) _0
+-- -1.5707963267948966
 atan2 :: (RealFloat a) => Quantity d a -> Quantity d a -> Dimensionless a
 atan2 = liftQ2 Prelude.atan2
 
@@ -678,6 +693,10 @@ If you feel your work requires this instance, it is provided as an orphan in "Nu
 -}
 
 -- | Convenient conversion between numerical types while retaining dimensional information.
+--
+-- >>> let x = (37 :: Rational) *~ poundMass
+-- >>> changeRep x :: Mass Double
+-- 16.78291769 kg
 changeRep :: (KnownVariant v, Real a, Fractional b) => Dimensional v d a -> Dimensional v d b
 changeRep = dmap realToFrac
 

--- a/src/Numeric/Units/Dimensional.hs
+++ b/src/Numeric/Units/Dimensional.hs
@@ -245,6 +245,7 @@ import qualified Numeric.Units.Dimensional.Variants as V
 -- >>> import Test.QuickCheck.Arbitrary
 -- >>> import Numeric.Units.Dimensional.Prelude
 -- >>> import Numeric.Units.Dimensional.Float
+-- >>> import Numeric.Units.Dimensional.NonSI
 -- >>> instance Arbitrary a => Arbitrary (Quantity d a) where arbitrary = fmap Quantity arbitrary
 
 {-
@@ -523,10 +524,19 @@ xs /~~ u = fmap (/~ u) xs
 infixl 7  *~~, /~~
 
 -- | The sum of all elements in a list.
+--
+-- >>> sum ([] :: [Mass Double])
+-- 0.0 kg
+--
+-- >>> sum [12.4 *~ meter, 1 *~ foot]
+-- 12.7048 m
 sum :: (Num a, Foldable f) => f (Quantity d a) -> Quantity d a
 sum = foldr (+) _0
 
 -- | The arithmetic mean of all elements in a list.
+--
+-- >>> mean [pi, _7]
+-- 5.070796326794897
 mean :: (Fractional a, Foldable f) => f (Quantity d a) -> Quantity d a
 mean = uncurry (/) . foldr accumulate (_0, _0)
   where
@@ -534,6 +544,9 @@ mean = uncurry (/) . foldr accumulate (_0, _0)
 
 -- | The length of the foldable data structure as a 'Dimensionless'.
 -- This can be useful for purposes of e.g. calculating averages.
+--
+-- >>> dimensionlessLength [_0, pi, _7]
+-- 3.0
 dimensionlessLength :: (Num a, Foldable f) => f (Dimensional v d a) -> Dimensionless a
 dimensionlessLength x = (fromIntegral $ length x) *~ one
   where
@@ -608,9 +621,9 @@ good measure.
 
 -}
 
--- | The constant for zero is polymorphic, allowing
--- it to express zero 'Length' or 'Capacitance' or 'Velocity' etc, in addition
--- to the 'Dimensionless' value zero.
+-- | The constant for zero is polymorphic, allowing it to express zero 'Length' or
+-- 'Numeric.Units.Dimensional.Quantities.Capacitance' or 'Numeric.Units.Dimensional.Quantities.Velocity' etc,
+-- in addition to the 'Dimensionless' value zero.
 _0 :: Num a => Quantity d a
 _0 = Quantity 0
 

--- a/src/Numeric/Units/Dimensional.hs
+++ b/src/Numeric/Units/Dimensional.hs
@@ -566,6 +566,19 @@ dimensionlessLength :: (Num a, Foldable f) => f b -> Dimensionless a
 dimensionlessLength x = (fromIntegral $ length x) *~ one
 
 -- | Returns a list of quantities between given bounds.
+--
+-- prop> n <= 0 ==> nFromTo (x :: Mass Double) (y :: Mass Double) n == [x, y]
+--
+-- prop> (x :: Length Double) <= (y :: Length Double) ==> all (\z -> x <= z && z <= y) (nFromTo x y n)
+--
+-- >>> nFromTo _0 _3 2
+-- [0.0,1.0,2.0,3.0]
+--
+-- >>> nFromTo _1 _0 7
+-- [1.0,0.875,0.75,0.625,0.5,0.375,0.25,0.125,0.0]
+--
+-- >>> nFromTo _0 _1 (-5)
+-- [0.0,1.0]
 nFromTo :: (Fractional a, Integral b) => Quantity d a -- ^ The initial value.
                                       -> Quantity d a -- ^ The final value.
                                       -> b -- ^ The number of intermediate values. If less than one, no intermediate values will result.

--- a/src/Numeric/Units/Dimensional/Float.hs
+++ b/src/Numeric/Units/Dimensional/Float.hs
@@ -26,6 +26,10 @@ import qualified Prelude as P
 import Numeric.Units.Dimensional.Prelude hiding (RealFloat(..))
 import Numeric.Units.Dimensional.Coercion
 
+-- $setup
+-- >>> :set -XExtendedDefaultRules
+-- >>> :set -XNegativeLiterals
+
 -- | 'True' if the representation of the argument is too small to be represented in normalized format.
 isDenormalized :: RealFloat a => Quantity d a -> Bool
 isDenormalized = P.isDenormalized . unQuantity
@@ -44,14 +48,35 @@ isFiniteNumber :: RealFloat a => Quantity d a -> Bool
 isFiniteNumber = not . liftA2 (||) isNaN isInfinite
 
 -- | 'True' if the representation of the argument is an IEEE infinity or negative infinity.
+--
+-- >>> isInfinite (_1 / _0)
+-- True
+--
+-- >>> isInfinite (42 *~ micro farad)
+-- False
 isInfinite :: RealFloat a => Quantity d a -> Bool
 isInfinite = P.isInfinite . unQuantity
 
 -- | 'True' if the representation of the argument is an IEEE "not-a-number" (NaN) value.
+--
+-- >>> isNaN _3
+-- False
+--
+-- >>> isNaN (_1 / _0)
+-- False
+--
+-- >>> isNaN (asin _4)
+-- True
 isNaN :: RealFloat a => Quantity d a -> Bool
 isNaN = P.isNaN . unQuantity
 
 -- | 'True' if the representation of the argument is an IEEE negative zero.
+--
+-- >>> isNegativeZero _0
+-- False
+--
+-- >>> isNegativeZero $ (-1e-200 *~ one) * (1e-200 *~ one)
+-- True
 isNegativeZero :: RealFloat a => Quantity d a -> Bool
 isNegativeZero = P.isNegativeZero . unQuantity
 
@@ -59,8 +84,8 @@ isNegativeZero = P.isNegativeZero . unQuantity
 --
 -- Use 'P.floatRadix' to determine the radix.
 --
--- >>> let x = 3.7 *~ meter
--- >>> scaleFloat 3 x == _8 * x
--- True
+-- >>> let x = 3 *~ meter
+-- >>> scaleFloat 3 x
+-- 24.0 m
 scaleFloat :: RealFloat a => Int -> Quantity d a -> Quantity d a
 scaleFloat x = Quantity . P.scaleFloat x . unQuantity

--- a/src/Numeric/Units/Dimensional/Internal.hs
+++ b/src/Numeric/Units/Dimensional/Internal.hs
@@ -50,6 +50,10 @@ import Prelude
   , show, otherwise, undefined, error, fmap
   )
 
+-- $setup
+-- >>> :set -XNoImplicitPrelude
+-- >>> import Numeric.Units.Dimensional.Prelude
+
 -- | A unit of measurement.
 type Unit (m :: Metricality) = Dimensional ('DUnit m)
 
@@ -198,6 +202,9 @@ instance (KnownDimension d, Show a, Fractional a) => Show (Quantity d a) where
   show = showIn siUnit
 
 -- | Shows the value of a 'Quantity' expressed in a specified 'Unit' of the same 'Dimension'.
+--
+-- >>> showIn watt $ (37 *~ volt) * (4 *~ ampere)
+-- "148.0 W"
 showIn :: (KnownDimension d, Show a, Fractional a) => Unit m d a -> Quantity d a -> String
 showIn (Unit n _ y) (Quantity x) | Name.weaken n == nOne = show (x / y)
                                  | otherwise             = (show (x / y)) ++ " " ++ (show n)

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -86,10 +86,10 @@ had a combined uncertainty of 0.0000010e-27 kg.
 -}
 
 electronVolt :: Floating a => Unit 'Metric DEnergy a
-electronVolt = mkUnitR (ucumMetric "eV" "eV" "electron volt") (Approximate 1.60217733e-19) $ joule
+electronVolt = mkUnitR (ucumMetric "eV" "eV" "electron volt") 1.60217733e-19 $ joule
 
 unifiedAtomicMassUnit :: Floating a => Unit 'Metric DMass a
-unifiedAtomicMassUnit = mkUnitR (ucumMetric "u" "u" "atomic mass unit") (Approximate 1.6605402e-27) $ kilo gram
+unifiedAtomicMassUnit = mkUnitR (ucumMetric "u" "u" "atomic mass unit") 1.6605402e-27 $ kilo gram
 
 dalton :: Floating a => Unit 'Metric DMass a
 dalton = mkUnitR (ucumMetric "eV" "Da" "Dalton") 1 $ unifiedAtomicMassUnit
@@ -310,11 +310,17 @@ technicalAtmosphere = mkUnitQ (ucum "att" "at" "technical atmosphere") 1 $ kilo 
 --
 -- The chosen fluid density approximately corresponds to that of mercury
 -- at 0 deg. Under most conditions, 1 mmHg is approximately equal to 1 'torr'.
-mmHg :: (Floating a) => Unit 'NonMetric DPressure a
+--
+-- >>> 1 *~ mmHg
+-- 133.322 m^-1 kg s^-2
+--
+-- >>> 1 *~ mmHg :: Pressure Rational
+-- 66661 % 500 m^-1 kg s^-2
+mmHg :: (Fractional a) => Unit 'NonMetric DPressure a
 mmHg = milli mHg
 
-mHg :: (Floating a) => Unit 'Metric DPressure a
-mHg = mkUnitR (ucumMetric "m[Hg]" "m Hg" "meter of mercury") (Approximate 133.3220) $ kilo pascal
+mHg :: (Fractional a) => Unit 'Metric DPressure a
+mHg = mkUnitQ (ucumMetric "m[Hg]" "m Hg" "meter of mercury") 133.3220 $ kilo pascal
 
 -- | The conventional value for the pressure exerted by a 1 inch high column of mercury.
 --
@@ -322,7 +328,13 @@ mHg = mkUnitR (ucumMetric "m[Hg]" "m Hg" "meter of mercury") (Approximate 133.32
 -- meteorological or aeronautical contexts in the United States.
 --
 -- This is the value defined by UCUM. For the value defined by NIST, see 'inHg_NIST'.
-inHg :: (Floating a) => Unit 'NonMetric DPressure a
+--
+-- >>> 1 *~ inHg
+-- 3386.3788 m^-1 kg s^-2
+--
+-- >>> 1 *~ inHg :: Pressure Rational
+-- 8465947 % 2500 m^-1 kg s^-2
+inHg :: (Fractional a) => Unit 'NonMetric DPressure a
 inHg = inHg_UCUM
 
 -- | The conventional value for the pressure exerted by a 1 inch high column of mercury.
@@ -331,8 +343,14 @@ inHg = inHg_UCUM
 -- meteorological or aeronautical contexts in the United States.
 --
 -- This is the value defined by UCUM. For the value defined by NIST, see 'inHg_NIST'.
-inHg_UCUM :: (Floating a) => Unit 'NonMetric DPressure a
-inHg_UCUM = mkUnitR (ucum "[in_i'Hg]" "in Hg" "inch of mercury") 1 $ mHg * inch / meter
+--
+-- >>> 1 *~ inHg_UCUM
+-- 3386.3788 m^-1 kg s^-2
+--
+-- >>> 1 *~ inHg_UCUM :: Pressure Rational
+-- 8465947 % 2500 m^-1 kg s^-2
+inHg_UCUM :: (Fractional a) => Unit 'NonMetric DPressure a
+inHg_UCUM = mkUnitQ (ucum "[in_i'Hg]" "in Hg" "inch of mercury") 1 $ mHg * inch / meter
 
 -- | The conventional value for the pressure exerted by a 1 inch high column of mercury.
 --
@@ -340,8 +358,14 @@ inHg_UCUM = mkUnitR (ucum "[in_i'Hg]" "in Hg" "inch of mercury") 1 $ mHg * inch 
 -- meteorological or aeronautical contexts in the United States.
 --
 -- This is the value defined by NIST. For the value defined by UCUM, see 'inHg_UCUM'.
-inHg_NIST :: (Floating a) => Unit 'NonMetric DPressure a
-inHg_NIST = mkUnitR (dimensionalAtom "[in_i'Hg_NIST]" "in Hg" "inch of mercury") 3.386389 $ pascal
+--
+-- >>> 1 *~ inHg_NIST
+-- 3.386389 m^-1 kg s^-2
+--
+-- >>> 1 *~ inHg_NIST :: Pressure Rational
+-- 3386389 % 1000000 m^-1 kg s^-2
+inHg_NIST :: (Fractional a) => Unit 'NonMetric DPressure a
+inHg_NIST = mkUnitQ (dimensionalAtom "[in_i'Hg_NIST]" "in Hg" "inch of mercury") 3.386389 $ pascal
 
 -- | One torr (symbol: Torr) is defined as 1/760 atm, which is approximately equal to 1 'mmHg'.
 torr :: (Fractional a) => Unit 'NonMetric DPressure a

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -435,14 +435,27 @@ The IAU recommends <#note2 [2]> that:
   several kinds of day), it is best to regard a year as a julian
   year of 365.25 days (31.5576 Ms) unless otherwise specified.
 
-We define the year in terms of seconds in order to avoid a 'Fractional'
-constraint, and also provide a Julian century.
-
 -}
 
+-- | One mean Julian year is a unit of measurement of time defined as exactly 365.25 days of 86400 'second's each.
+--
+-- See <https://en.wikipedia.org/wiki/Julian_year_%28astronomy%29 here> for further information.
+--
+-- >>> 1 *~ year
+-- 3.15576e7 s
+--
+-- >>> 1 *~ year :: Time Rational
+-- 31557600 % 1 s
 year :: Num a => Unit 'NonMetric DTime a
-year    = mkUnitZ (ucum "a_j" "a" "mean Julian year") 31557600 $ second
+year = mkUnitZ (ucum "a_j" "a" "mean Julian year") 31557600 $ second
 
+-- | One mean Julain century is one hundred mean Julian 'year's.
+--
+-- >>> 1 *~ century
+-- 3.15576e9 s
+--
+-- >>> 1 *~ century :: Time Rational
+-- 3155760000 % 1 s
 century :: Num a => Unit 'NonMetric DTime a
 century = mkUnitZ (dimensionalAtom "c_j" "cen" "mean Julian century") 100 $ year
 
@@ -579,7 +592,15 @@ torr = mkUnitQ (dimensionalAtom "Torr" "Torr" "Torr") (1 Prelude./ 760) $ atmosp
 rad :: (Fractional a) => Unit 'Metric DAbsorbedDose a
 rad = mkUnitQ (ucumMetric "RAD" "RAD" "RAD") 1 $ centi gray
 
-{- Kinematic Viscosity -}
+-- | One Stokes is a unit of 'KinematicViscosity' equal to @1 cm^2 / s@.
+--
+-- See <https://en.wikipedia.org/wiki/Viscosity#Kinematic_viscosity_.CE.BD here> for further information.
+--
+-- >>> 1 *~ stokes
+-- 1.0e-4 m^2 s^-1
+--
+-- >>> 1 *~ stokes :: KinematicViscosity Rational
+-- 1 % 10000 m^2 s^-1
 stokes :: (Fractional a) => Unit 'Metric DKinematicViscosity a
 stokes = mkUnitQ (ucumMetric "St" "St" "Stokes") 1 $ centi meter ^ pos2 / second
 

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -115,27 +115,60 @@ poundMass, ounce :: Fractional a => Unit 'NonMetric DMass a
 poundMass = mkUnitQ (ucum "[lb_av]" "lb" "pound") 0.45359237 $ kilo gram
 ounce     = mkUnitQ (ucum "[oz_av]" "oz" "ounce") (1 Prelude./ 16) $ poundMass
 
+-- | The pound-force is equal to the gravitational force exerted on a mass
+-- of one avoirdupois pound on the surface of Earth.
+--
+-- This definition is based on standard gravity (the 'gee') and the
+-- international avoirdupois 'poundMass'.
+--
+-- See <https://en.wikipedia.org/wiki/Pound_%28force%29 here> for further information.
+--
+-- >>> 1 *~ poundForce
+-- 4.4482216152605 m kg s^-2
+--
+-- >>> 1 *~ poundForce :: Force Rational
+-- 8896443230521 % 2000000000000 m kg s^-2
 poundForce :: Fractional a => Unit 'NonMetric DForce a
-poundForce = mkUnitQ (ucum "[lbf_av]" "lbf" "pound force") 1 $ poundMass * gee  -- 4.4482 N
+poundForce = mkUnitQ (ucum "[lbf_av]" "lbf" "pound force") 1 $ poundMass * gee
 
+-- | One mechanical horsepower is by definition the power necessary
+-- to apply a force of 550 'poundForce' through a distance of one 'foot'
+-- per 'second'.
+--
+-- See <https://en.wikipedia.org/wiki/Horsepower#Mechanical_horsepower here> for further information.
+--
+-- >>> 1 *~ horsepower
+-- 745.6998715822702 m^2 kg s^-3
+--
+-- >>> 1 *~ horsepower :: Power Rational
+-- 37284993579113511 % 50000000000000 m^2 kg s^-3
 horsepower :: Fractional a => Unit 'NonMetric DPower a
 horsepower = mkUnitQ (ucum "[HP]" "hp" "horsepower") 550 $ foot * poundForce / second
 
-{-
-
-The slug is an alternative unit of mass defined in terms of the pound-force.
-
--}
-
+-- | The slug is a unit of mass associated with Imperial units and United States customary units.
+-- It is a mass that accelerates by 1 foot per second per second when a force of one pound is exerted on it.
+--
+-- This definition is based on standard gravity (the 'gee'), the international 'foot', and the international avoirdupois 'poundMass'.
+--
+-- See <https://en.wikipedia.org/wiki/Slug_%28mass%29 here> for further information.
+--
+-- >>> 1 *~ slug
+-- 14.593902937206364 kg 
+--
+-- >>> 1 *~ slug :: Mass Rational
+-- 8896443230521 % 609600000000 kg
 slug :: Fractional a => Unit 'NonMetric DMass a
 slug = mkUnitQ (dimensionalAtom "slug" "slug" "slug") 1 $ poundForce * (second^pos2) / foot
 
-{-
-
-Pounds of force per square inch.
-
--}
-
+-- | One psi is a pressure of one 'poundForce' per 'square' 'inch' of area.
+--
+-- See <https://en.wikipedia.org/wiki/Pounds_per_square_inch here> for further information.
+--
+-- >>> 1 *~ psi
+-- 6894.757293168362 m^-1 kg s^-2
+--
+-- >>> 1 *~ psi :: Pressure Rational
+-- 8896443230521 % 1290320000 m^-1 kg s^-2
 psi :: Fractional a => Unit 'NonMetric DPressure a
 psi = mkUnitQ (ucum "[psi]" "psi" "pound per square inch") 1 $ poundForce / inch ^ pos2
 

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -240,6 +240,7 @@ bar = mkUnitZ (ucumMetric "bar" "bar" "bar") 1e5 $ pascal
 --
 -- >>> 1 *~ atmosphere
 -- 101325.0 m^-1 kg s^-2
+--
 -- >>> 1 *~ atmosphere :: Pressure Rational
 -- 101325 % 1 m^-1 kg s^-2
 atmosphere :: (Num a) => Unit 'NonMetric DPressure a
@@ -254,6 +255,7 @@ atmosphere = mkUnitZ (ucum "atm" "atm" "standard atmosphere") 101325 $ pascal
 --
 -- >>> 1 *~ technicalAtmosphere
 -- 98066.5 m^-1 kg s^-2
+--
 -- >>> 1 *~ technicalAtmosphere :: Pressure Rational
 -- 196133 % 2 m^-1 kg s^-2
 technicalAtmosphere :: (Fractional a) => Unit 'NonMetric DPressure a

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -87,8 +87,10 @@ had a combined uncertainty of 0.0000010e-27 kg.
 
 electronVolt :: Floating a => Unit 'Metric DEnergy a
 electronVolt = mkUnitR (ucumMetric "eV" "eV" "electron volt") (Approximate 1.60217733e-19) $ joule
+
 unifiedAtomicMassUnit :: Floating a => Unit 'Metric DMass a
 unifiedAtomicMassUnit = mkUnitR (ucumMetric "u" "u" "atomic mass unit") (Approximate 1.6605402e-27) $ kilo gram
+
 dalton :: Floating a => Unit 'Metric DMass a
 dalton = mkUnitR (ucumMetric "eV" "Da" "Dalton") 1 $ unifiedAtomicMassUnit
 
@@ -107,13 +109,20 @@ gee = mkUnitQ (ucumMetric "[g]" "g" "gee") 9.80665 $ meter / second ^ pos2
 Some US customary (that is, inch-pound) units.
 -}
 
-inch, foot, mil :: Fractional a => Unit 'NonMetric DLength a
+inch :: Fractional a => Unit 'NonMetric DLength a
 inch = mkUnitQ (ucum "[in_i]" "in" "inch") 2.54 $ centi meter
-foot = mkUnitQ (ucum "[ft_i]" "ft" "foot") 12 $ inch     -- 0.3048 m
-mil  = mkUnitQ (ucum "[mil_i]" "mil" "mil") 0.001 $ inch
-poundMass, ounce :: Fractional a => Unit 'NonMetric DMass a
+
+foot :: Fractional a => Unit 'NonMetric DLength a
+foot = mkUnitQ (ucum "[ft_i]" "ft" "foot") 12 $ inch
+
+mil :: Fractional a => Unit 'NonMetric DLength a
+mil = mkUnitQ (ucum "[mil_i]" "mil" "mil") 0.001 $ inch
+
+poundMass :: Fractional a => Unit 'NonMetric DMass a
 poundMass = mkUnitQ (ucum "[lb_av]" "lb" "pound") 0.45359237 $ kilo gram
-ounce     = mkUnitQ (ucum "[oz_av]" "oz" "ounce") (1 Prelude./ 16) $ poundMass
+
+ounce :: Fractional a => Unit 'NonMetric DMass a
+ounce = mkUnitQ (ucum "[oz_av]" "oz" "ounce") (1 Prelude./ 16) $ poundMass
 
 -- | The pound-force is equal to the gravitational force exerted on a mass
 -- of one avoirdupois pound on the surface of Earth.
@@ -178,19 +187,27 @@ psi = mkUnitQ (ucum "[psi]" "psi" "pound per square inch") 1 $ poundForce / inch
 
 -}
 
-yard, mile :: (Fractional a) => Unit 'NonMetric DLength a
+yard :: (Fractional a) => Unit 'NonMetric DLength a
 yard = mkUnitQ (ucum "[yd_i]" "yd" "yard") 3 $ foot
+
+mile :: (Fractional a) => Unit 'NonMetric DLength a
 mile = mkUnitQ (ucum "[mi_i]" "mi" "mile") 5280 $ foot
+
 nauticalMile :: (Num a) => Unit 'NonMetric DLength a
 nauticalMile = mkUnitZ (ucum "[nmi_i]" "NM" "nautical mile") 1852 $ meter
+
 knot :: (Fractional a) => Unit 'NonMetric DVelocity a
 knot = mkUnitQ (ucum "[kt_i]" "kt" "knot") 1 $ nauticalMile / hour
+
 revolution :: (Floating a) => Unit 'NonMetric DOne a
 revolution = mkUnitR (dimensionalAtom "rev" "rev" "revolution") (2 Prelude.* Prelude.pi) $ radian
+
 solid :: (Floating a) => Unit 'NonMetric DOne a
 solid = mkUnitR (dimensionalAtom "solid" "solid" "solid") (4 Prelude.* Prelude.pi) $ steradian
+
 teaspoon :: (Fractional a) => Unit 'NonMetric DVolume a
 teaspoon = mkUnitQ (ucum "[tsp_m]" "tsp" "teaspoon") 5 $ milli liter
+
 acre :: (Fractional a) => Unit 'NonMetric DArea a
 acre = mkUnitQ (ucum "[acr_us]" "ac" "acre") 43560 $ square foot
 
@@ -207,8 +224,10 @@ constraint, and also provide a Julian century.
 
 -}
 
-year, century :: Num a => Unit 'NonMetric DTime a
+year :: Num a => Unit 'NonMetric DTime a
 year    = mkUnitZ (ucum "a_j" "a" "mean Julian year") 31557600 $ second
+
+century :: Num a => Unit 'NonMetric DTime a
 century = mkUnitZ (dimensionalAtom "c_j" "cen" "mean Julian century") 100 $ year
 
 {- $pressure-units
@@ -329,25 +348,43 @@ degreeRankine = mkUnitQ (ucum "[degR]" "°R" "degree Rankine") 1 $ degreeFahrenh
 Per http://en.wikipedia.org/wiki/Imperial_units and http://en.wikipedia.org/wiki/Cup_(unit)#Imperial_cup.
 -}
 
-imperialGallon, imperialQuart, imperialPint, imperialCup,
-                imperialGill, imperialFluidOunce
-                :: (Fractional a) => Unit 'NonMetric DVolume a
-imperialGallon     = mkUnitQ (ucum "[gal_br]" "gal" "gallon")         4.54609          $ liter
-imperialQuart      = mkUnitQ (ucum "[qt_br]" "qt" "quart")            (1 Prelude./ 4)  $ imperialGallon
-imperialPint       = mkUnitQ (ucum "[pt_br]" "pt" "pint")             (1 Prelude./ 8)  $ imperialGallon
-imperialCup        = mkUnitQ (dimensionalAtom "[cup_br]" "cup" "cup") 0.5              $ imperialPint
-imperialGill       = mkUnitQ (ucum "[gil_br]" "gill" "gill")          (1 Prelude./ 4)  $ imperialPint
-imperialFluidOunce = mkUnitQ (ucum "[foz_br]" "fl oz" "fluid ounce")  (1 Prelude./ 20) $ imperialPint
+imperialGallon :: (Fractional a) => Unit 'NonMetric DVolume a
+imperialGallon = mkUnitQ (ucum "[gal_br]" "gal" "gallon") 4.54609 $ liter
+
+imperialQuart :: (Fractional a) => Unit 'NonMetric DVolume a
+imperialQuart = mkUnitQ (ucum "[qt_br]" "qt" "quart") (1 Prelude./ 4) $ imperialGallon
+
+imperialPint :: (Fractional a) => Unit 'NonMetric DVolume a
+imperialPint = mkUnitQ (ucum "[pt_br]" "pt" "pint") (1 Prelude./ 8) $ imperialGallon
+
+imperialCup :: (Fractional a) => Unit 'NonMetric DVolume a
+imperialCup = mkUnitQ (dimensionalAtom "[cup_br]" "cup" "cup") 0.5 $ imperialPint
+
+imperialGill :: (Fractional a) => Unit 'NonMetric DVolume a
+imperialGill = mkUnitQ (ucum "[gil_br]" "gill" "gill") (1 Prelude./ 4) $ imperialPint
+
+imperialFluidOunce :: (Fractional a) => Unit 'NonMetric DVolume a
+imperialFluidOunce = mkUnitQ (ucum "[foz_br]" "fl oz" "fluid ounce") (1 Prelude./ 20) $ imperialPint
 
 {- $us-customary-volumes
 Per http://www.nist.gov/pml/wmd/pubs/upload/2012-hb44-final.pdf page 452 and http://en.wikipedia.org/wiki/United_States_customary_units#Fluid_volume
 Note that there exist rarely-used "dry" variants of units with overlapping names.
 -}
 
-usGallon, usQuart, usPint, usCup, usGill, usFluidOunce :: (Fractional a) => Unit 'NonMetric DVolume a
-usGallon     = mkUnitQ (ucum "[gal_us]" "gal" "gallon")        231              $ (cubic inch)
-usQuart      = mkUnitQ (ucum "[qt_us]" "qt" "quart")           (1 Prelude./ 4)  $ usGallon
-usPint       = mkUnitQ (ucum "[pt_us]" "pt" "pint")            (1 Prelude./ 8)  $ usGallon
-usCup        = mkUnitQ (ucum "[cup_us]" "cup" "cup")           (1 Prelude./ 2)  $ usPint
-usGill       = mkUnitQ (ucum "[gil_us]" "gill" "gill")         (1 Prelude./ 4)  $ usPint
+usGallon :: (Fractional a) => Unit 'NonMetric DVolume a
+usGallon = mkUnitQ (ucum "[gal_us]" "gal" "gallon") 231 $ (cubic inch)
+
+usQuart :: (Fractional a) => Unit 'NonMetric DVolume a
+usQuart = mkUnitQ (ucum "[qt_us]" "qt" "quart") (1 Prelude./ 4) $ usGallon
+
+usPint :: (Fractional a) => Unit 'NonMetric DVolume a
+usPint = mkUnitQ (ucum "[pt_us]" "pt" "pint") (1 Prelude./ 8) $ usGallon
+
+usCup :: (Fractional a) => Unit 'NonMetric DVolume a
+usCup = mkUnitQ (ucum "[cup_us]" "cup" "cup") (1 Prelude./ 2) $ usPint
+
+usGill :: (Fractional a) => Unit 'NonMetric DVolume a
+usGill = mkUnitQ (ucum "[gil_us]" "gill" "gill") (1 Prelude./ 4) $ usPint
+
+usFluidOunce :: (Fractional a) => Unit 'NonMetric DVolume a
 usFluidOunce = mkUnitQ (ucum "[foz_us]" "fl oz" "fluid ounce") (1 Prelude./ 16) $ usPint -- sic, does not match factor used in imperial system

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -607,9 +607,34 @@ stokes = mkUnitQ (ucumMetric "St" "St" "Stokes") 1 $ centi meter ^ pos2 / second
 {- $temperature
 These units of temperature are relative. For absolute temperatures, see 'Numeric.Units.Dimensional.SIUnits.fromDegreeCelsiusAbsolute'.
 -}
+
+-- | One degree Fahrenheit is a unit of relative temperature equal to 5/9 'kelvin'.
+--
+-- Note that although the Fahrenheit scale is an absolute temperature scale, this unit is a unit of difference within
+-- that scale and measures relative temperature.
+--
+-- See <https://en.wikipedia.org/wiki/Fahrenheit#Definition_and_conversions here> for further information.
+--
+-- >>> 1 *~ degreeFahrenheit
+-- 0.5555555555555556 K
+--
+-- >>> 1 *~ degreeFahrenheit :: ThermodynamicTemperature Rational
+-- 5 % 9 K
 degreeFahrenheit :: (Fractional a) => Unit 'NonMetric DThermodynamicTemperature a
 degreeFahrenheit = mkUnitQ (ucum "[degF]" "°F" "degree Fahrenheit") (5 Prelude./ 9) $ degreeCelsius
 
+-- | One degree Rankine is a unit of relative temperature equal to 5/9 'kelvin'.
+--
+-- Note that although the Rankine scale is an absolute temperature scale, this unit is a unit of difference within
+-- that scale and measures relative temperature.
+--
+-- See <https://en.wikipedia.org/wiki/Rankine_scale here> for further information.
+--
+-- >>> 1 *~ degreeRankine
+-- 0.5555555555555556 K
+--
+-- >>> 1 *~ degreeRankine :: ThermodynamicTemperature Rational
+-- 5 % 9 K
 degreeRankine :: (Fractional a) => Unit 'NonMetric DThermodynamicTemperature a
 degreeRankine = mkUnitQ (ucum "[degR]" "°R" "degree Rankine") 1 $ degreeFahrenheit
 
@@ -640,20 +665,74 @@ Per http://www.nist.gov/pml/wmd/pubs/upload/2012-hb44-final.pdf page 452 and htt
 Note that there exist rarely-used "dry" variants of units with overlapping names.
 -}
 
+-- | One US liquid gallon is a volume of 231 cubic inches.
+--
+-- See <https://en.wikipedia.org/wiki/Gallon#The_US_liquid_gallon here> for further information.
+--
+-- >>> 1 *~ usGallon
+-- 3.785411784e-3 m^3
+--
+-- >>> 1 *~ usGallon :: Volume Rational
+-- 473176473 % 125000000000 m^3
 usGallon :: (Fractional a) => Unit 'NonMetric DVolume a
 usGallon = mkUnitQ (ucum "[gal_us]" "gal" "gallon") 231 $ (cubic inch)
 
+-- | One US liquid quart is one quarter of a 'usGallon'.
+--
+-- See <https://en.wikipedia.org/wiki/United_States_customary_units#Fluid_volume here> for further information.
+--
+-- >>> 1 *~ usQuart
+-- 9.46352946e-4 m^3
+--
+-- >>> 1 *~ usQuart :: Volume Rational
+-- 473176473 % 500000000000 m^3
 usQuart :: (Fractional a) => Unit 'NonMetric DVolume a
 usQuart = mkUnitQ (ucum "[qt_us]" "qt" "quart") (1 Prelude./ 4) $ usGallon
 
+-- | One US liquid pint is one half of a 'usQuart'.
+--
+-- See <https://en.wikipedia.org/wiki/United_States_customary_units#Fluid_volume here> for further information.
+--
+-- >>> 1 *~ usPint
+-- 4.73176473e-4 m^3
+--
+-- >>> 1 *~ usPint :: Volume Rational
+-- 473176473 % 1000000000000 m^3
 usPint :: (Fractional a) => Unit 'NonMetric DVolume a
 usPint = mkUnitQ (ucum "[pt_us]" "pt" "pint") (1 Prelude./ 8) $ usGallon
 
+-- | One US liquid cup is one half of a 'usPint'.
+--
+-- See <https://en.wikipedia.org/wiki/United_States_customary_units#Fluid_volume here> for further information.
+--
+-- >>> 1 *~ usCup
+-- 2.365882365e-4 m^3
+--
+-- >>> 1 *~ usCup :: Volume Rational
+-- 473176473 % 2000000000000 m^3
 usCup :: (Fractional a) => Unit 'NonMetric DVolume a
 usCup = mkUnitQ (ucum "[cup_us]" "cup" "cup") (1 Prelude./ 2) $ usPint
 
+-- | One US liquid gill is one half of a 'usCup'.
+--
+-- See <https://en.wikipedia.org/wiki/United_States_customary_units#Fluid_volume here> for further information.
+--
+-- >>> 1 *~ usGill
+-- 1.1829411825e-4 m^3
+--
+-- >>> 1 *~ usGill :: Volume Rational
+-- 473176473 % 4000000000000 m^3
 usGill :: (Fractional a) => Unit 'NonMetric DVolume a
 usGill = mkUnitQ (ucum "[gil_us]" "gill" "gill") (1 Prelude./ 4) $ usPint
 
+-- | One US fluid ounce is 1/128 'usGallon' or 1/8 'usCup'.
+--
+-- See <https://en.wikipedia.org/wiki/United_States_customary_units#Fluid_volume here> for further information.
+--
+-- >>> 1 *~ usFluidOunce
+-- 2.95735295625e-5 m^3
+--
+-- >>> 1 *~ usFluidOunce :: Volume Rational
+-- 473176473 % 16000000000000 m^3
 usFluidOunce :: (Fractional a) => Unit 'NonMetric DVolume a
 usFluidOunce = mkUnitQ (ucum "[foz_us]" "fl oz" "fluid ounce") (1 Prelude./ 16) $ usPint -- sic, does not match factor used in imperial system

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -221,6 +221,12 @@ We include some of the common ones here. 'psi' was defined earlier.
 -- From Wikipedia:
 --
 --  It is about equal to the atmospheric pressure on Earth at sea level.
+--
+-- >>> 1 *~ bar
+-- 100000.0 m^-1 kg s^-2
+--
+-- >>> 1 *~ bar :: Pressure Rational
+-- 100000 % 1 m^-1 kg s^-2
 bar :: (Num a) => Unit 'Metric DPressure a
 bar = mkUnitZ (ucumMetric "bar" "bar" "bar") 1e5 $ pascal
 
@@ -231,6 +237,11 @@ bar = mkUnitZ (ucumMetric "bar" "bar" "bar") 1e5 $ pascal
 --  The standard atmosphere (atm) is an established constant. It is
 --  approximately equal to typical air pressure at earth mean sea
 --  level.
+--
+-- >>> 1 *~ atmosphere
+-- 101325.0 m^-1 kg s^-2
+-- >>> 1 *~ atmosphere :: Pressure Rational
+-- 101325 % 1 m^-1 kg s^-2
 atmosphere :: (Num a) => Unit 'NonMetric DPressure a
 atmosphere = mkUnitZ (ucum "atm" "atm" "standard atmosphere") 101325 $ pascal
 
@@ -240,6 +251,11 @@ atmosphere = mkUnitZ (ucum "atm" "atm" "standard atmosphere") 101325 $ pascal
 --
 --  A technical atmosphere (symbol: at) is a non-SI unit of pressure equal
 --  to one kilogram-force per square centimeter.
+--
+-- >>> 1 *~ technicalAtmosphere
+-- 98066.5 m^-1 kg s^-2
+-- >>> 1 *~ technicalAtmosphere :: Pressure Rational
+-- 196133 % 2 m^-1 kg s^-2
 technicalAtmosphere :: (Fractional a) => Unit 'NonMetric DPressure a
 technicalAtmosphere = mkUnitQ (ucum "att" "at" "technical atmosphere") 1 $ kilo gram * gee * centi meter ^ neg2
 
@@ -250,7 +266,7 @@ technicalAtmosphere = mkUnitQ (ucum "att" "at" "technical atmosphere") 1 $ kilo 
 --  The pressure exerted at the base of a column of fluid exactly 1 mm high,
 --  when the density of the fluid is exactly 13.5951 g/cm^3, at a place
 --  where the acceleration of gravity is exactly 9.80665 m/s^2.
-
+--
 -- The chosen fluid density approximately corresponds to that of mercury
 -- at 0 deg. Under most conditions, 1 mmHg is approximately equal to 1 'torr'.
 mmHg :: (Floating a) => Unit 'NonMetric DPressure a

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -193,9 +193,29 @@ yard = mkUnitQ (ucum "[yd_i]" "yd" "yard") 3 $ foot
 mile :: (Fractional a) => Unit 'NonMetric DLength a
 mile = mkUnitQ (ucum "[mi_i]" "mi" "mile") 5280 $ foot
 
+-- | One nautical mile is a unit of length, set by international agreement as being exactly 1,852 meters.
+--
+-- Historically, it was defined as the distance spanned by one minute of arc along a meridian of the Earth.
+--
+-- See <https://en.wikipedia.org/wiki/Nautical_mile here> for further information.
+--
+-- >>> 1 *~ nauticalMile
+-- 1852.0 m
+--
+-- >>> 1 *~ nauticalMile :: Length Rational
+-- 1852 % 1 m
 nauticalMile :: (Num a) => Unit 'NonMetric DLength a
 nauticalMile = mkUnitZ (ucum "[nmi_i]" "NM" "nautical mile") 1852 $ meter
 
+-- | One knot is a velocity equal to one 'nauticalMile' per 'hour'.
+--
+-- See <https://en.wikipedia.org/wiki/Knot_%28unit%29 here> for further information.
+--
+-- >>> 1 *~ knot
+-- 0.5144444444444445 m s^-1
+--
+-- >>> 1 *~ knot :: Velocity Rational
+-- 463 % 900 m s^-1
 knot :: (Fractional a) => Unit 'NonMetric DVelocity a
 knot = mkUnitQ (ucum "[kt_i]" "kt" "knot") 1 $ nauticalMile / hour
 

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -588,7 +588,16 @@ inHg_NIST = mkUnitQ (dimensionalAtom "[in_i'Hg_NIST]" "in Hg" "inch of mercury")
 torr :: (Fractional a) => Unit 'NonMetric DPressure a
 torr = mkUnitQ (dimensionalAtom "Torr" "Torr" "Torr") (1 Prelude./ 760) $ atmosphere
 
-{- Radiation -}
+-- | The rad is a deprecated unit of 'AbsorbedDose', defined as
+-- 0.01 'gray'.
+--
+-- See <https://en.wikipedia.org/wiki/Rad_%28unit%29 here> for further information.
+--
+-- >>> 1 *~ rad
+-- 1.0e-2 m^2 s^-2
+--
+-- >>> 1 *~ rad :: AbsorbedDose Rational
+-- 1 % 100 m^2 s^-2
 rad :: (Fractional a) => Unit 'Metric DAbsorbedDose a
 rad = mkUnitQ (ucumMetric "RAD" "RAD" "RAD") 1 $ centi gray
 

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -360,12 +360,12 @@ inHg_UCUM = mkUnitQ (ucum "[in_i'Hg]" "in Hg" "inch of mercury") 1 $ mHg * inch 
 -- This is the value defined by NIST. For the value defined by UCUM, see 'inHg_UCUM'.
 --
 -- >>> 1 *~ inHg_NIST
--- 3.386389 m^-1 kg s^-2
+-- 3386.389 m^-1 kg s^-2
 --
 -- >>> 1 *~ inHg_NIST :: Pressure Rational
--- 3386389 % 1000000 m^-1 kg s^-2
+-- 3386389 % 1000 m^-1 kg s^-2
 inHg_NIST :: (Fractional a) => Unit 'NonMetric DPressure a
-inHg_NIST = mkUnitQ (dimensionalAtom "[in_i'Hg_NIST]" "in Hg" "inch of mercury") 3.386389 $ pascal
+inHg_NIST = mkUnitQ (dimensionalAtom "[in_i'Hg_NIST]" "in Hg" "inch of mercury") 3.386389e3 $ pascal
 
 -- | One torr (symbol: Torr) is defined as 1/760 atm, which is approximately equal to 1 'mmHg'.
 torr :: (Fractional a) => Unit 'NonMetric DPressure a

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -642,21 +642,79 @@ degreeRankine = mkUnitQ (ucum "[degR]" "°R" "degree Rankine") 1 $ degreeFahrenh
 Per http://en.wikipedia.org/wiki/Imperial_units and http://en.wikipedia.org/wiki/Cup_(unit)#Imperial_cup.
 -}
 
+-- | One imperial gallon is defined exactly in terms of the 'liter'
+-- by the Weights and Measures Act 1985.
+--
+-- See <https://en.wikipedia.org/wiki/Imperial_units#Volume here> for further information.
+--
+-- >>> 1 *~ imperialGallon
+-- 4.54609e-3 m^3
+--
+-- >>> 1 *~ imperialGallon :: Volume Rational
+-- 454609 % 100000000 m^3
 imperialGallon :: (Fractional a) => Unit 'NonMetric DVolume a
 imperialGallon = mkUnitQ (ucum "[gal_br]" "gal" "gallon") 4.54609 $ liter
 
+-- | One imperial quart is one quarter of an 'imperialGallon'.
+--
+-- See <https://en.wikipedia.org/wiki/Imperial_units#Volume here> for further information.
+--
+-- >>> 1 *~ imperialQuart
+-- 1.1365225e-3 m^3
+--
+-- >>> 1 *~ imperialQuart :: Volume Rational
+-- 454609 % 400000000 m^3
 imperialQuart :: (Fractional a) => Unit 'NonMetric DVolume a
 imperialQuart = mkUnitQ (ucum "[qt_br]" "qt" "quart") (1 Prelude./ 4) $ imperialGallon
 
+-- | One imperial pint is one half of an 'imperialQuart'.
+--
+-- See <https://en.wikipedia.org/wiki/Imperial_units#Volume here> for further information.
+--
+-- >>> 1 *~ imperialPint
+-- 5.6826125e-4 m^3
+--
+-- >>> 1 *~ imperialPint :: Volume Rational
+-- 454609 % 800000000 m^3
 imperialPint :: (Fractional a) => Unit 'NonMetric DVolume a
 imperialPint = mkUnitQ (ucum "[pt_br]" "pt" "pint") (1 Prelude./ 8) $ imperialGallon
 
+-- | One imperial cup is one half of an 'imperialPint'.
+--
+-- This unit is not in common use and is does not appear in some sources
+-- describing the imperial fluid volume units.
+--
+-- See <https://en.wikipedia.org/wiki/Cup_%28unit%29#Imperial_cup here> for further information.
+--
+-- >>> 1 *~ imperialCup
+-- 2.84130625e-4 m^3
+--
+-- >>> 1 *~ imperialCup :: Volume Rational
+-- 454609 % 1600000000 m^3
 imperialCup :: (Fractional a) => Unit 'NonMetric DVolume a
 imperialCup = mkUnitQ (dimensionalAtom "[cup_br]" "cup" "cup") 0.5 $ imperialPint
 
+-- | One imperial gill is one quarter of an 'imperialPint'.
+--
+-- See <https://en.wikipedia.org/wiki/Imperial_units#Volume here> for further information.
+--
+-- >>> 1 *~ imperialGill
+-- 1.420653125e-4 m^3
+--
+-- >>> 1 *~ imperialGill :: Volume Rational
+-- 454609 % 3200000000 m^3
 imperialGill :: (Fractional a) => Unit 'NonMetric DVolume a
 imperialGill = mkUnitQ (ucum "[gil_br]" "gill" "gill") (1 Prelude./ 4) $ imperialPint
 
+-- | One imperial fluid ounce is one twentieth of an 'imperialPint'.
+--
+-- See <https://en.wikipedia.org/wiki/Imperial_units#Volume here> for further information.
+--
+-- >>> 1 *~ imperialFluidOunce
+-- 2.84130625e-5 m^3
+--
+-- >>> 1 *~ imperialFluidOunce :: Volume Rational
+-- 454609 % 16000000000 m^3
 imperialFluidOunce :: (Fractional a) => Unit 'NonMetric DVolume a
 imperialFluidOunce = mkUnitQ (ucum "[foz_br]" "fl oz" "fluid ounce") (1 Prelude./ 20) $ imperialPint
 

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -292,9 +292,28 @@ usSurveyMile = mkUnitQ (ucum "[mi_us]" "mi" "mile") 5280 $ usSurveyFoot
 usSurveyAcre :: (Fractional a) => Unit 'NonMetric DArea a
 usSurveyAcre = mkUnitQ (ucum "[acr_us]" "ac" "acre") 43560 $ square usSurveyFoot
 
+-- | One avoirdupois pound is a mass, exactly defined in terms of the kilogram by the international
+-- yard and pound agreement of 1959.
+--
+-- See <https://en.wikipedia.org/wiki/Avoirdupois#Internationalization here> for further information.
+--
+-- >>> 1 *~ poundMass
+-- 0.45359237 kg
+--
+-- >>> 1 *~ poundMass :: Mass Rational
+-- 45359237 % 100000000 kg
 poundMass :: Fractional a => Unit 'NonMetric DMass a
 poundMass = mkUnitQ (ucum "[lb_av]" "lb" "pound") 0.45359237 $ kilo gram
 
+-- | One avoirdupois ounce is one sixteenth of a 'poundMass'.
+--
+-- See <https://en.wikipedia.org/wiki/Ounce#International_avoirdupois_ounce here> for further information.
+--
+-- >>> 1 *~ ounce
+-- 2.8349523125e-2 kg
+--
+-- >>> 1 *~ ounce :: Mass Rational
+-- 45359237 % 1600000000 kg
 ounce :: Fractional a => Unit 'NonMetric DMass a
 ounce = mkUnitQ (ucum "[oz_av]" "oz" "ounce") (1 Prelude./ 16) $ poundMass
 

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -40,13 +40,18 @@ module Numeric.Units.Dimensional.NonSI
   -- $values-obtained-experimentally
   electronVolt, unifiedAtomicMassUnit, dalton,
   -- * Standard Gravity
-  -- $standard-gravity
   gee,
   -- * Inch-pound Units
   -- $inch-pound-units
-  inch, foot, mil, poundMass, ounce, poundForce, horsepower,
-  slug, psi, yard, mile, nauticalMile, knot,
-  revolution, solid, teaspoon, acre,
+  poundMass, ounce, poundForce, horsepower,
+  nauticalMile, knot,
+  revolution, solid,
+  slug, psi,
+  teaspoon,
+  -- ** International Foot
+  foot, inch, mil, yard, mile, acre,
+  -- ** US Survey Foot
+  usSurveyFoot, usSurveyInch, usSurveyMil, usSurveyYard, usSurveyMile, usSurveyAcre,
   -- * Years
   -- $year
   year, century,
@@ -69,7 +74,6 @@ module Numeric.Units.Dimensional.NonSI
 )
 where
 
-import Data.ExactPi
 import Numeric.Units.Dimensional.Prelude
 import Numeric.Units.Dimensional.UnitNames.Internal (ucumMetric, ucum, dimensionalAtom)
 import qualified Prelude
@@ -94,14 +98,19 @@ unifiedAtomicMassUnit = mkUnitR (ucumMetric "u" "u" "atomic mass unit") 1.660540
 dalton :: Floating a => Unit 'Metric DMass a
 dalton = mkUnitR (ucumMetric "eV" "Da" "Dalton") 1 $ unifiedAtomicMassUnit
 
-{- $standard-gravity
-In order to relate e.g. pounds mass to pounds force we define the unit
-'gee' equal to the standard gravity g_0: the nominal acceleration of a
-body in free fall in a vacuum near the surface of the earth (note that
-local values of acceleration due to gravity will differ from the standard
-gravity). I.e. g_0 = 1 gee.
--}
-
+-- | One gee is the standard value of the acceleration due to gravity at the
+-- Earth's surface, as standardized by CIPM.
+--
+-- Note that local values of acceleration due to gravity will differ from the
+-- standard gravity.
+--
+-- See <https://en.wikipedia.org/wiki/Standard_gravity here> for further information.
+--
+-- >>> 1 *~ gee
+-- 9.80665 m s^-2
+--
+-- >>> 1 *~ gee :: Acceleration Rational
+-- 196133 % 20000 m s^-2
 gee :: Fractional a => Unit 'Metric DAcceleration a
 gee = mkUnitQ (ucumMetric "[g]" "g" "gee") 9.80665 $ meter / second ^ pos2
 
@@ -109,14 +118,179 @@ gee = mkUnitQ (ucumMetric "[g]" "g" "gee") 9.80665 $ meter / second ^ pos2
 Some US customary (that is, inch-pound) units.
 -}
 
-inch :: Fractional a => Unit 'NonMetric DLength a
-inch = mkUnitQ (ucum "[in_i]" "in" "inch") 2.54 $ centi meter
-
+-- | One international foot is one third of an international 'yard'.
+--
+-- See <https://en.wikipedia.org/wiki/Foot_%28unit%29#International_foot here> for further information.
+--
+-- >>> 1 *~ foot
+-- 0.3048 m
+--
+-- >>> 1 *~ foot :: Length Rational
+-- 381 % 1250 m
 foot :: Fractional a => Unit 'NonMetric DLength a
-foot = mkUnitQ (ucum "[ft_i]" "ft" "foot") 12 $ inch
+foot = mkUnitQ (ucum "[ft_i]" "ft" "foot") (1 Prelude./ 3) $ yard
 
+-- | One inch is one twelth of a 'foot'.
+--
+-- This inch is based on the international 'foot'.
+--
+-- See <https://en.wikipedia.org/wiki/Inch#Modern_standardisation here> for further information.
+--
+-- >>> 1 *~ inch
+-- 2.54e-2 m
+--
+-- >>> 1 *~ inch :: Length Rational
+-- 127 % 5000 m
+inch :: Fractional a => Unit 'NonMetric DLength a
+inch = mkUnitQ (ucum "[in_i]" "in" "inch") (1 Prelude./ 12) $ foot
+
+-- | One mil is one thousandth of an 'inch'.
+--
+-- This mil is based on the international 'inch'.
+--
+-- See <https://en.wikipedia.org/wiki/Thousandth_of_an_inch here> for further information.
+--
+-- >>> 1 *~ mil
+-- 2.54e-5 m
+--
+-- >>> 1 *~ mil :: Length Rational
+-- 127 % 5000000 m
 mil :: Fractional a => Unit 'NonMetric DLength a
 mil = mkUnitQ (ucum "[mil_i]" "mil" "mil") 0.001 $ inch
+
+-- | One yard, as defined by international agreement in 1959, is precisely
+-- 0.9144 'meter'.
+--
+-- See <https://en.wikipedia.org/wiki/Yard here> for further information.
+--
+-- >>> 1 *~ yard
+-- 0.9144 m
+--
+-- >>> 1 *~ yard :: Length Rational
+-- 1143 % 1250 m
+yard :: (Fractional a) => Unit 'NonMetric DLength a
+yard = mkUnitQ (ucum "[yd_i]" "yd" "yard") 0.9144 $ meter
+
+-- | One mile is 5,280 feet.
+--
+-- This mile is based on the international 'foot'.
+--
+-- See <https://en.wikipedia.org/wiki/Mile#International_mile here> for further information.
+--
+-- >>> 1 *~ mile
+-- 1609.344 m
+--
+-- >>> 1 *~ mile :: Length Rational
+-- 201168 % 125 m
+mile :: (Fractional a) => Unit 'NonMetric DLength a
+mile = mkUnitQ (ucum "[mi_i]" "mi" "mile") 5280 $ foot
+
+-- | One acre is 43,560 square feet.
+--
+-- This acre is based on the international 'foot'. For the acre based on the US Survey Foot,
+-- see 'usSurveyAcre'. While both acres are in use, the difference between them is of little consequence
+-- for most applications in which either is used.
+--
+-- See <https://en.wikipedia.org/wiki/Acre#Differences_between_international_and_US_survey_acres here> for further information.
+--
+-- >>> 1 *~ acre
+-- 4046.8564224 m^2
+--
+-- >>> 1 *~ acre :: Area Rational
+-- 316160658 % 78125 m^2
+acre :: (Fractional a) => Unit 'NonMetric DArea a
+acre = mkUnitQ (dimensionalAtom "[acr_i]" "ac" "acre") 43560 $ square foot
+
+-- | One US survey foot is 1200/3937 'meter'.
+--
+-- For the international foot, see 'foot'. Note that this is not the foot in routine use
+-- in the United States.
+--
+-- See <https://en.wikipedia.org/wiki/Foot_%28unit%29#US_survey_foot here> for further information.
+--
+-- >>> 1 *~ usSurveyFoot
+-- 0.3048006096012192 m
+--
+-- >>> 1 *~ usSurveyFoot :: Length Rational
+-- 1200 % 3937 m
+usSurveyFoot :: Fractional a => Unit 'NonMetric DLength a
+usSurveyFoot = mkUnitQ (ucum "[ft_us]" "ft" "foot") (1200 Prelude./ 3937) $ meter
+
+-- | One inch is one twelth of a foot.
+--
+-- This inch is based on the 'usSurveyFoot'. For the inch based on the international foot,
+-- see 'inch'. Note that this is not the inch in routine use in the United States.
+--
+-- See <https://en.wikipedia.org/wiki/Inch here> for further information.
+--
+-- >>> 1 *~ usSurveyInch
+-- 2.54000508001016e-2 m
+--
+-- >>> 1 *~ usSurveyInch :: Length Rational
+-- 100 % 3937 m
+usSurveyInch :: Fractional a => Unit 'NonMetric DLength a
+usSurveyInch = mkUnitQ (ucum "[in_us]" "in" "inch") (1 Prelude./ 12) $ usSurveyFoot
+
+-- | One mil is one thousandth of an inch.
+--
+-- This mil is based on the 'usSurveyInch'. For the mil based on the international inch,
+-- see 'mil'. Note that this is not the mil in routine use in the United States.
+--
+-- See <https://en.wikipedia.org/wiki/Thousandth_of_an_inch here> for further information.
+--
+-- >>> 1 *~ usSurveyMil
+-- 2.54000508001016e-5 m
+--
+-- >>> 1 *~ usSurveyMil :: Length Rational
+-- 1 % 39370 m
+usSurveyMil :: Fractional a => Unit 'NonMetric DLength a
+usSurveyMil = mkUnitQ (ucum "[mil_us]" "mil" "mil") 0.001 $ usSurveyInch
+
+-- | One yard is three feet.
+--
+-- This yard is based on the 'usSurveyFoot'. For the international yard,
+-- see 'yard'. Note that this is not the yard in routine use in the United States.
+--
+-- See <https://en.wikipedia.org/wiki/Yard here> for further information.
+--
+-- >>> 1 *~ usSurveyYard
+-- 0.9144018288036576 m
+--
+-- >>> 1 *~ usSurveyYard :: Length Rational
+-- 3600 % 3937 m
+usSurveyYard :: (Fractional a) => Unit 'NonMetric DLength a
+usSurveyYard = mkUnitQ (ucum "[yd_us]" "yd" "yard") 3 $ usSurveyFoot
+
+-- | One US survey mile is 5,280 US survey feet.
+--
+-- This mile is based on the 'usSurveyFoot'. For the mile based on the international foot,
+-- see 'mile'. Note that this is not the mile in routine use in the United States.
+--
+-- See <https://en.wikipedia.org/wiki/Mile#US_survey_mile here> for further information.
+--
+-- >>> 1 *~ usSurveyMile
+-- 1609.3472186944373 m
+--
+-- >>> 1 *~ usSurveyMile :: Length Rational
+-- 6336000 % 3937 m
+usSurveyMile :: (Fractional a) => Unit 'NonMetric DLength a
+usSurveyMile = mkUnitQ (ucum "[mi_us]" "mi" "mile") 5280 $ usSurveyFoot
+
+-- | One acre is 43,560 square feet.
+--
+-- This acre is based on the 'usSurveyFoot'. For the acre based on the international foot,
+-- see 'acre'. While both acres are in use, the difference between them is of little consequence
+-- for most applications in which either is used. This is the only acre defined by the UCUM.
+--
+-- See <https://en.wikipedia.org/wiki/Acre#Differences_between_international_and_US_survey_acres here> for further information.
+--
+-- >>> 1 *~ usSurveyAcre
+-- 4046.872609874252 m^2
+--
+-- >>> 1 *~ usSurveyAcre :: Area Rational
+-- 62726400000 % 15499969 m^2
+usSurveyAcre :: (Fractional a) => Unit 'NonMetric DArea a
+usSurveyAcre = mkUnitQ (ucum "[acr_us]" "ac" "acre") 43560 $ square usSurveyFoot
 
 poundMass :: Fractional a => Unit 'NonMetric DMass a
 poundMass = mkUnitQ (ucum "[lb_av]" "lb" "pound") 0.45359237 $ kilo gram
@@ -181,18 +355,6 @@ slug = mkUnitQ (dimensionalAtom "slug" "slug" "slug") 1 $ poundForce * (second^p
 psi :: Fractional a => Unit 'NonMetric DPressure a
 psi = mkUnitQ (ucum "[psi]" "psi" "pound per square inch") 1 $ poundForce / inch ^ pos2
 
-{-
-
-= Various other (non inch-pound) units =
-
--}
-
-yard :: (Fractional a) => Unit 'NonMetric DLength a
-yard = mkUnitQ (ucum "[yd_i]" "yd" "yard") 3 $ foot
-
-mile :: (Fractional a) => Unit 'NonMetric DLength a
-mile = mkUnitQ (ucum "[mi_i]" "mi" "mile") 5280 $ foot
-
 -- | One nautical mile is a unit of length, set by international agreement as being exactly 1,852 meters.
 --
 -- Historically, it was defined as the distance spanned by one minute of arc along a meridian of the Earth.
@@ -227,9 +389,6 @@ solid = mkUnitR (dimensionalAtom "solid" "solid" "solid") (4 Prelude.* Prelude.p
 
 teaspoon :: (Fractional a) => Unit 'NonMetric DVolume a
 teaspoon = mkUnitQ (ucum "[tsp_m]" "tsp" "teaspoon") 5 $ milli liter
-
-acre :: (Fractional a) => Unit 'NonMetric DArea a
-acre = mkUnitQ (ucum "[acr_us]" "ac" "acre") 43560 $ square foot
 
 {- $year
 

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -367,7 +367,15 @@ inHg_UCUM = mkUnitQ (ucum "[in_i'Hg]" "in Hg" "inch of mercury") 1 $ mHg * inch 
 inHg_NIST :: (Fractional a) => Unit 'NonMetric DPressure a
 inHg_NIST = mkUnitQ (dimensionalAtom "[in_i'Hg_NIST]" "in Hg" "inch of mercury") 3.386389e3 $ pascal
 
--- | One torr (symbol: Torr) is defined as 1/760 atm, which is approximately equal to 1 'mmHg'.
+-- | One torr (symbol: Torr) is defined as 1/760 'atmosphere', which is approximately equal to 1 'mmHg'.
+--
+-- See <https://en.wikipedia.org/wiki/Torr here> for further information.
+--
+-- >>> 1 *~ torr
+-- 133.32236842105263 m^-1 kg s^-2
+--
+-- >>> 1 *~ torr :: Pressure Rational
+-- 20265 % 152 m^-1 kg s^-2
 torr :: (Fractional a) => Unit 'NonMetric DPressure a
 torr = mkUnitQ (dimensionalAtom "Torr" "Torr" "Torr") (1 Prelude./ 760) $ atmosphere
 

--- a/src/Numeric/Units/Dimensional/Quantities.hs
+++ b/src/Numeric/Units/Dimensional/Quantities.hs
@@ -414,13 +414,22 @@ to powers" of <#note1 [1]>).
 
 These definitions may seem slightly out of place but these is no
 obvious place where they should be. Here they are at least close
-to the definitions of 'DLength' and 'DVolume'.
+to the definitions of 'DArea' and 'DVolume'.
 -}
 
+-- $setup
+-- >>> import Numeric.Units.Dimensional.Prelude
+
 -- | Constructs a unit of area from a unit of length, taking the area of a square whose sides are that length.
+--
+-- >>> 64 *~ square meter == (8 *~ meter) ^ pos2
+-- True
 square :: (Fractional a, Typeable m) => Unit m DLength a -> Unit 'NonMetric DArea a
 square x = x ^ pos2
 
 -- | Constructs a unit of volume from a unit of length, taking the volume of a cube whose sides are that length.
+--
+-- >>> 64 *~ cubic meter == (4 *~ meter) ^ pos3
+-- True
 cubic  :: (Fractional a, Typeable m) => Unit m DLength a -> Unit 'NonMetric DVolume a
 cubic  x = x ^ pos3


### PR DESCRIPTION
Here are several more doctests, along with extensive documentation of most of the `NonSI` units. The goal is for the documentation of each of those units to include an explanation, a link to information about the definition and history of the unit, and the equivalent value in SI units (as a doctest, so that it can be verified).

A few things snuck in here that I found while doing this work, including a minor documentation bug, an issue with the definition of the acre (#144), a cleanup of the misguided attempt to use the `Approximate` constructor from `ExactPi` to tag approximate conversion factors, and a whats-a-factor-of-10^3-between-friends typo in the definition of the NIST inHg.
