### PR TITLE
Parsing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ vNext
 * Added the Numeric.Units.Dimensional.Float module with convenient wrappers around functions
   from RealFloat and IEEE for inspecting floating point quantities.
 * Added an `AEq` instance for `Quantity`.
+* Exposed the name of an 'AnyUnit' without promoting it to a 'Unit' first.
+* Exposed a way to convert atomic 'UnitName's back into 'NameAtom's.
 * Added the `btu`, a unit of energy.
 * Relocated git repository to https://github.com/bjornbm/dimensional
 

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -236,7 +236,7 @@ data AnyUnit = AnyUnit Dimension' (UnitName 'NonMetric) ExactPi
   deriving (Generic, Typeable)
 
 instance Show AnyUnit where
-  show (AnyUnit _ n e) = "1 " ++ (show n) ++ " =def= " ++ (show e) ++ " of the SI base unit"
+  show (AnyUnit _ n e) = (show n) ++ " =def= " ++ (show e) ++ " of the SI base unit"
 
 instance HasDynamicDimension AnyUnit where
 
@@ -296,7 +296,7 @@ recip (AnyUnit d n e) = AnyUnit (D.recip d) (N.nOne N./ n) (P.recip e)
 
 -- | Raises a dynamic unit to an integer power.
 (^) :: (P.Integral a) => AnyUnit -> a -> AnyUnit
-(AnyUnit d n e) ^ x = AnyUnit (d D.^ P.fromIntegral x) (n N.^ P.fromIntegral x) (e P.^ x)
+(AnyUnit d n e) ^ x = AnyUnit (d D.^ P.fromIntegral x) (n N.^ P.fromIntegral x) (e P.^^ x)
 
 -- | Applies a prefix to a dynamic unit.
 -- Returns 'Nothing' if the 'Unit' was 'NonMetric' and thus could not accept a prefix.

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -27,11 +27,11 @@ module Numeric.Units.Dimensional.Dynamic
 , Promoteable
 , HasDynamicDimension(..)
 , promoteQuantity, demoteQuantity
-, (*~), (/~)
+, (*~), (/~), invalidQuantity
   -- * Dynamic Units
 , AnyUnit
 , demoteUnit, promoteUnit, demoteUnit'
-, siUnit
+, siUnit, anyUnitName
   -- ** Arithmetic on Dynamic Units
 , (*), (/), (^), recip, applyPrefix
 ) where
@@ -179,6 +179,9 @@ instance Num a => Monoid (DynQuantity a) where
   mempty = demoteQuantity (1 Dim.*~ one)
   mappend = (P.*)
 
+invalidQuantity :: DynQuantity a
+invalidQuantity = DynQuantity Nothing
+
 -- Lifts a function which is only valid on dimensionless quantities into a function on DynQuantitys.
 liftDimensionless :: (a -> a) -> DynQuantity a -> DynQuantity a
 liftDimensionless = liftDQ (matching D.dOne)
@@ -247,6 +250,9 @@ instance I.HasInterchangeName AnyUnit where
 instance Monoid AnyUnit where
   mempty = demoteUnit' one
   mappend = (Numeric.Units.Dimensional.Dynamic.*)
+
+anyUnitName :: AnyUnit -> UnitName 'NonMetric
+anyUnitName (AnyUnit _ n _) = n
 
 -- | The dynamic SI coherent unit of a given dimension.
 siUnit :: Dimension' -> AnyUnit

--- a/src/Numeric/Units/Dimensional/UnitNames.hs
+++ b/src/Numeric/Units/Dimensional/UnitNames.hs
@@ -27,7 +27,8 @@ module Numeric.Units.Dimensional.UnitNames
   -- * Convenience Type Synonyms for Unit Name Transformations
   UnitNameTransformer, UnitNameTransformer2,
   -- * Forgetting Unwanted Phantom Types
-  weaken, strengthen, relax
+  weaken, strengthen, relax,
+  name_en, abbreviation_en, asAtomic
 )
 where
 

--- a/src/Numeric/Units/Dimensional/UnitNames/Internal.hs
+++ b/src/Numeric/Units/Dimensional/UnitNames/Internal.hs
@@ -18,6 +18,7 @@ where
 
 import Control.DeepSeq
 import Control.Monad (join)
+import Data.Coerce
 import Data.Data hiding (Prefix)
 #if MIN_VERSION_base(4, 8, 0)
 import Data.Foldable (toList)
@@ -82,6 +83,12 @@ instance Show (UnitName m) where
   show (Power x n) = show x ++ "^" ++ show n
   show (Grouped n) = "(" ++ show n ++ ")"
   show (Weaken n) = show n
+
+asAtomic :: UnitName m -> Maybe (NameAtom ('UnitAtom m))
+asAtomic (MetricAtomic a) = Just a
+asAtomic (Atomic a) = Just a
+asAtomic (Weaken n) = fmap coerce $ asAtomic n
+asAtomic _ = Nothing
 
 isAtomic :: UnitName m -> Bool
 isAtomic (One) = True


### PR DESCRIPTION
Minor features required by `dimensional-parsers` to address #8, essentially exposing a bit more details about how to inspect unit names.

Exposed the name of an 'AnyUnit' without promoting it to a 'Unit' first.
Exposed a way to convert atomic 'UnitName's back into 'NameAtom's.
