### PR TITLE
 Changed import statement to be explicit about the fact that certain identifiers are types

### DIFF
--- a/src/Numeric/Units/Dimensional/Dimensions/TypeLevel.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions/TypeLevel.hs
@@ -38,7 +38,7 @@ where
 
 import Data.Proxy
 import Numeric.NumType.DK.Integers
-  ( TypeInt (Zero, Pos1, Pos2, Pos3), (+)(), (-)()
+  ( TypeInt (Zero, Pos1, Pos2, Pos3), type (+), type (-)
   , KnownTypeInt, toNum
   )
 import qualified Numeric.NumType.DK.Integers as N


### PR DESCRIPTION
Fixes part of the issue in #157 by addressing an issue in the GHC 8.0.1 release candidate.
