### PR TITLE
Maintenance release for GHC 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 .cabal-sandbox/
+.stack-work/
 cabal.sandbox.config
 *.hi
 *.o

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.1.2 (2016-05)
+-----------------
+* Support for GHC 8.0.1-rc4, avoiding GHC Trac issue 12026.
+* Added support for stack.
+
 1.0.1.1 (2015-11)
 -----------------
 * Improved example in readme.

--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -1,5 +1,5 @@
 name:                dimensional
-version:             1.0.1.1
+version:             1.0.1.2
 license:             BSD3
 license-file:        LICENSE
 copyright:           Bjorn Buckwalter 2006-2015

--- a/src/Numeric/Units/Dimensional/Dimensions/TypeLevel.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions/TypeLevel.hs
@@ -38,7 +38,7 @@ where
 
 import Data.Proxy
 import Numeric.NumType.DK.Integers
-  ( TypeInt (Zero, Pos1), (+)(), (-)()
+  ( TypeInt (Zero, Pos1), type (+), type (-)
   , KnownTypeInt, toNum
   )
 import qualified Numeric.NumType.DK.Integers as N

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,14 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-4.1
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}


### PR DESCRIPTION
Fixes #157 (for the released functionality, not for master, that will be addressed separately).

This version works on 7.84, 7.10.3, and 8.0.1-rc4.

Two new redundant constraint warnings introduced by GHC 8 are deliberately not fixed because doing so would change published types and require a major version bump. Those warnings (and a bunch of others) will be addressed by the planned 1.1 release.
