### PR TITLE
Ghc 8 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 - ARGS="--resolver lts-2 --stack-yaml stack.lts2.yaml"
 - ARGS="--resolver lts-3"
 - ARGS="--resolver lts-5"
+- ARGS="--resolver nightly-2016-05-21 --stack-yaml stack.ghc8.yaml"
 
 before_install:
 # Download and unpack the stack executable

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 # This line does all of the work: build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
-script: stack $ARGS --no-terminal test --haddock --bench
+script: stack $ARGS --no-terminal test --haddock --no-haddock-deps --bench
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ addons:
 # is too old to run our test suite.
 env:
 - ARGS="--resolver lts-2 --stack-yaml stack.lts2.yaml"
-- ARGS="--resolver lts-3"
+- ARGS="--resolver lts-3 --stack-yaml stack.lts3.yaml"
 - ARGS="--resolver lts-5"
-- ARGS="--resolver nightly-2016-05-21 --stack-yaml stack.ghc8.yaml"
+- ARGS="--resolver nightly --stack-yaml stack.ghc8.yaml"
 
 before_install:
 # Download and unpack the stack executable

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -87,7 +87,7 @@ instance (KnownDimension d) => Demotable (Quantity d) where
       demoteQ (AnyQuantity dim val) | dim == dim' = Just . Quantity $ val
                                     | otherwise   = Nothing
         where
-          dim' = dimension (Proxy :: Proxy d)
+          dim' = dimension (Proxy :: Proxy d')
 
 
 

--- a/src/Numeric/Units/Dimensional/Internal.hs
+++ b/src/Numeric/Units/Dimensional/Internal.hs
@@ -87,7 +87,7 @@ class KnownVariant (v :: Variant) where
 
 deriving instance Typeable Dimensional
 
-instance (E.KnownExactPi s) => KnownVariant ('DQuantity s) where
+instance KnownVariant ('DQuantity s) where
   newtype Dimensional ('DQuantity s) d a = Quantity a
     deriving (Eq, Ord, AEq, Data, Generic, Generic1
 #if MIN_VERSION_base(4,8,0)
@@ -142,7 +142,7 @@ We provide this freedom by making 'Dimensionless' an instance of
 'Functor'.
 -}
 
-instance (E.KnownExactPi s) => Functor (SQuantity s DOne) where
+instance Functor (SQuantity s DOne) where
   fmap = dmap
 
 instance (KnownDimension d) => HasDynamicDimension (Dimensional v d a) where
@@ -223,14 +223,14 @@ instance (KnownDimension d, E.KnownExactPi s, Show a, Real a) => Show (SQuantity
 --
 -- >>> showIn watt $ (37 *~ volt) * (4 *~ ampere)
 -- "148.0 W"
-showIn :: (KnownDimension d, Show a, Fractional a) => Unit m d a -> Quantity d a -> String
+showIn :: (Show a, Fractional a) => Unit m d a -> Quantity d a -> String
 showIn (Unit n _ y) (Quantity x) = show (x / y) ++ (showName . Name.weaken $ n)
 
 showName :: UnitName 'NonMetric -> String
 showName n | n == nOne = ""
            | otherwise = " " ++ show n
 
-instance (KnownDimension d, Show a) => Show (Unit m d a) where
+instance (Show a) => Show (Unit m d a) where
   show (Unit n e x) = "The unit " ++ show n ++ ", with value " ++ show e ++ " (or " ++ show x ++ ")"
 
 -- Operates on a dimensional value using a unary operation on values, possibly yielding a Unit.

--- a/stack.ghc8.yaml
+++ b/stack.ghc8.yaml
@@ -1,14 +1,23 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
-# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.17
-
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
+  - array-0.5.1.1
+  - containers-0.5.7.1
+  - deepseq-1.4.2.0
+  - directory-1.2.6.3
+  - filepath-1.4.1.0
+  - process-1.4.2.0
+  - transformers-0.5.2.0
+  - transformers-compat-0.5.1.4
+  - unix-2.7.2.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}
+
+resolver: nightly-2016-05-21
+compiler: ghc-8.0.1

--- a/stack.ghc8.yaml
+++ b/stack.ghc8.yaml
@@ -6,15 +6,9 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-  - array-0.5.1.1
-  - containers-0.5.7.1
-  - deepseq-1.4.2.0
   - directory-1.2.6.3
-  - filepath-1.4.1.0
-  - process-1.4.2.0
-  - transformers-0.5.2.0
-  - transformers-compat-0.5.1.4
-  - unix-2.7.2.0
+  - exact-pi-0.4.1.2
+  - numtype-dk-0.5.0.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.ghc8.yaml
+++ b/stack.ghc8.yaml
@@ -6,12 +6,11 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-  - directory-1.2.6.3
   - exact-pi-0.4.1.2
   - numtype-dk-0.5.0.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}
 
-resolver: nightly-2016-05-21
+resolver: nightly-2016-05-31
 compiler: ghc-8.0.1

--- a/stack.lts2.yaml
+++ b/stack.lts2.yaml
@@ -9,8 +9,8 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- exact-pi-0.4.1.0
-- numtype-dk-0.5
+- exact-pi-0.4.1.2
+- numtype-dk-0.5.0.1
 - doctest-0.10.1
 
 # Override default flag values for local packages and extra-deps

--- a/stack.lts3.yaml
+++ b/stack.lts3.yaml
@@ -1,0 +1,17 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.22
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+  - exact-pi-0.4.1.2
+  - numtype-dk-0.5.0.1
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+


### PR DESCRIPTION
Fixed a number of redundant constraint warnings that were introduced in GHC 8. Left 3 that I deem intentional.

Upgraded build process to include routine builds on GHC 8, using stackage nightly which just recently transitioned to GHC 8.0.1.
