### PR TITLE
Improved GHCI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist
 .cabal-sandbox/
 .stack-work/
+.ghci
 cabal.sandbox.config
 *.hi
 *.o

--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -50,6 +50,7 @@ library
                        vector >= 0.10
   hs-source-dirs:      src
   default-language:    Haskell2010
+  default-extensions:  NoImplicitPrelude
   ghc-options:         -Wall
   exposed-modules:     Numeric.Units.Dimensional,
                        Numeric.Units.Dimensional.Coercion,

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -15,7 +15,6 @@ Defines types for manipulation of units and quantities without phantom types for
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Numeric.Units.Dimensional.Dynamic

--- a/src/Numeric/Units/Dimensional/UnitNames/InterchangeNames.hs
+++ b/src/Numeric/Units/Dimensional/UnitNames/InterchangeNames.hs
@@ -12,6 +12,7 @@ where
 import Control.DeepSeq
 import Data.Data
 import GHC.Generics
+import Prelude
 
 -- | Represents the authority which issued an interchange name for a unit.
 data InterchangeNameAuthority = UCUM -- ^ The interchange name originated with the Unified Code for Units of Measure.

--- a/src/Numeric/Units/Dimensional/Variants.hs
+++ b/src/Numeric/Units/Dimensional/Variants.hs
@@ -33,6 +33,7 @@ import Control.DeepSeq
 import Data.Data
 import qualified Data.ExactPi.TypeLevel as E
 import GHC.Generics
+import Prelude
 
 -- | Encodes whether a unit is a metric unit, that is, whether it can be combined
 -- with a metric prefix to form a related unit.


### PR DESCRIPTION
Fixes #168 by providing support for building all modules with the `-XNoImplicitPrelude` flag set in GHCI. This therefore allows placement of that flag, should a user choose to do so, in a `.ghci` file in the project directory. A change was also made to the `.gitignore` file to ignore such `.ghci` files.
