### PR TITLE
Release 1.1 to Hackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-vNext
------
+1.0.1.4 (2018-03)
+-----------------
+* Added `Semigroup` instances for [GHC 8.4 compatibility](https://ghc.haskell.org/trac/ghc/wiki/Migration/8.4#SemigroupMonoidsuperclasses).
 * Breaking: Renamed `Root` type family to `NRoot`. Added `Sqrt` and `Cbrt` type
   synonyms. Added `sqrt` and `cbrt` for term level dimensions.
 * Breaking: Changed `Numeric.Units.Dimensional.Prelude` to export dimensionally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-1.0.1.4 (2018-03)
------------------
+1.1 (2018-03)
+-------------
 * Added `Semigroup` instances for [GHC 8.4 compatibility](https://ghc.haskell.org/trac/ghc/wiki/Migration/8.4#SemigroupMonoidsuperclasses).
 * Breaking: Renamed `Root` type family to `NRoot`. Added `Sqrt` and `Cbrt` type
   synonyms. Added `sqrt` and `cbrt` for term level dimensions.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2014, Bjorn Buckwalter.
+Copyright (c) 2006-2018, Bjorn Buckwalter.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -1,5 +1,5 @@
 name:                dimensional
-version:             1.0.1.4
+version:             1.1
 license:             BSD3
 license-file:        LICENSE
 copyright:           Bjorn Buckwalter 2006-2018

--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -2,7 +2,7 @@ name:                dimensional
 version:             1.0.1.4
 license:             BSD3
 license-file:        LICENSE
-copyright:           Bjorn Buckwalter 2006-2015
+copyright:           Bjorn Buckwalter 2006-2018
 author:              Bjorn Buckwalter
 maintainer:          bjorn@buckwalter.se
 stability:           experimental

--- a/src/Numeric/Units/Dimensional.hs
+++ b/src/Numeric/Units/Dimensional.hs
@@ -20,7 +20,7 @@
 
 
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/Coercion.hs
+++ b/src/Numeric/Units/Dimensional/Coercion.hs
@@ -1,5 +1,5 @@
 {- |
-    Copyright  : Copyright (C) 2006-2014 Bjorn Buckwalter
+    Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
     License    : BSD3
 
     Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/Dimensions.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions.hs
@@ -1,5 +1,5 @@
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/Dimensions/TypeLevel.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions/TypeLevel.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE TypeOperators #-}
 
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -1,5 +1,5 @@
 {- |
-    Copyright  : Copyright (C) 2006-2014 Bjorn Buckwalter
+    Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
     License    : BSD3
 
     Maintainer : bjorn@buckwalter.se
@@ -79,7 +79,7 @@ promoteQuantity = promoteQ . promotableOut
                                | otherwise                 = Nothing
 
 instance (KnownDimension d) => Demotable (Quantity d) where
-  demotableOut q@(Quantity x) = AnyQuantity (dimension q) x    
+  demotableOut q@(Quantity x) = AnyQuantity (dimension q) x
 
 -- | A 'Quantity' whose 'Dimension' is only known dynamically.
 data AnyQuantity a = AnyQuantity !Dimension' !a

--- a/src/Numeric/Units/Dimensional/FixedPoint.hs
+++ b/src/Numeric/Units/Dimensional/FixedPoint.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeOperators #-}
 
 {- |
-    Copyright  : Copyright (C) 2006-2014 Bjorn Buckwalter
+    Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
     License    : BSD3
 
     Maintainer : bjorn@buckwalter.se
@@ -282,10 +282,10 @@ Changes of Representation
 
 -- | Convenient conversion between numerical types while retaining dimensional information.
 changeRep :: forall v1 v2 d a b.
-            (KnownVariant v1, KnownVariant v2, 
+            (KnownVariant v1, KnownVariant v2,
              CompatibleVariants v1 v2,
              E.MinCtxt (ScaleFactor v1 E./ ScaleFactor v2) b,
-             Real a, Fractional b) 
+             Real a, Fractional b)
           => Dimensional v1 d a -> Dimensional v2 d b
 changeRep = liftD (P.* s) ((P.* s') . realToFrac) Name.weaken
   where
@@ -296,10 +296,10 @@ changeRep = liftD (P.* s) ((P.* s') . realToFrac) Name.weaken
 
 -- | Convenient conversion to types with `Integral` representations using `round`.
 changeRepRound :: forall v1 v2 d a b.
-                 (KnownVariant v1, KnownVariant v2, 
+                 (KnownVariant v1, KnownVariant v2,
                   CompatibleVariants v1 v2,
                   E.MinCtxt (ScaleFactor v1 E./ ScaleFactor v2) a,
-                  RealFrac a, Integral b) 
+                  RealFrac a, Integral b)
                => Dimensional v1 d a -> Dimensional v2 d b
 changeRepRound = liftD (P.* s) (round . (P.* s')) Name.weaken
   where

--- a/src/Numeric/Units/Dimensional/Float.hs
+++ b/src/Numeric/Units/Dimensional/Float.hs
@@ -1,5 +1,5 @@
 {- |
-    Copyright  : Copyright (C) 2006-2016 Bjorn Buckwalter
+    Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
     License    : BSD3
 
     Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/Functor.hs
+++ b/src/Numeric/Units/Dimensional/Functor.hs
@@ -10,7 +10,7 @@
 #endif
 
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE NumDecimals #-}
 
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/Prelude.hs
+++ b/src/Numeric/Units/Dimensional/Prelude.hs
@@ -1,5 +1,5 @@
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/Quantities.hs
+++ b/src/Numeric/Units/Dimensional/Quantities.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE DataKinds #-}
 
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/SIUnits.hs
+++ b/src/Numeric/Units/Dimensional/SIUnits.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/UnitNames.hs
+++ b/src/Numeric/Units/Dimensional/UnitNames.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se

--- a/src/Numeric/Units/Dimensional/Variants.hs
+++ b/src/Numeric/Units/Dimensional/Variants.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE TypeOperators #-}
 
 {- |
-   Copyright  : Copyright (C) 2006-2015 Bjorn Buckwalter
+   Copyright  : Copyright (C) 2006-2018 Bjorn Buckwalter
    License    : BSD3
 
    Maintainer : bjorn@buckwalter.se


### PR DESCRIPTION
In order to get the GHC 8.4 compatibility fixes from @varosi to Hackage …

Since we have a bunch of other (breaking) changes in the changelog. I plan to publish version 1.1 in a day or two. @dmcclean: do you see any reason to **not** publish the changes in master? Do they warrant a version 2.0 instead of 1.1?