### PR TITLE
Remove `semigroups` dependency

### DIFF
--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -46,8 +46,7 @@ library
                        exact-pi >= 0.4.1 && < 0.6,
                        ieee754 >= 0.7.6,
                        numtype-dk >= 0.5 && < 1.1,
-                       vector >= 0.10,
-                       semigroups
+                       vector >= 0.10
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude

--- a/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
+++ b/src/Numeric/Units/Dimensional/Dimensions/TermLevel.hs
@@ -64,7 +64,7 @@ instance Semigroup Dimension' where
 -- | The monoid of dimensions under multiplication.
 instance Monoid Dimension' where
   mempty = dOne
-  mappend = (Data.Semigroup.<>)
+  mappend = (<>)
 
 -- | The dimension of a dynamic value, which may not have any dimension at all.
 data DynamicDimension = NoDimension -- ^ The value has no valid dimension.

--- a/src/Numeric/Units/Dimensional/Dynamic.hs
+++ b/src/Numeric/Units/Dimensional/Dynamic.hs
@@ -113,7 +113,7 @@ instance Num a => Semigroup (AnyQuantity a) where
 -- they may not be added together if their dimensions do not match.
 instance Num a => Monoid (AnyQuantity a) where
   mempty = demoteQuantity (1 Dim.*~ one)
-  mappend = (Data.Semigroup.<>)
+  mappend = (<>)
 
 -- | Possibly a 'Quantity' whose 'Dimension' is only known dynamically.
 --
@@ -192,7 +192,7 @@ instance Num a => Semigroup (DynQuantity a) where
 -- they may not be added together if their dimensions do not match.
 instance Num a => Monoid (DynQuantity a) where
   mempty = demoteQuantity (1 Dim.*~ one)
-  mappend = (Data.Semigroup.<>)
+  mappend = (<>)
 
 -- | A 'DynQuantity' which does not correspond to a value of any dimension.
 invalidQuantity :: DynQuantity a
@@ -282,7 +282,7 @@ instance Semigroup AnyUnit where
 -- | 'AnyUnit's form a 'Monoid' under multiplication.
 instance Monoid AnyUnit where
   mempty = demoteUnit' one
-  mappend = (Data.Semigroup.<>)
+  mappend = (<>)
 
 anyUnitName :: AnyUnit -> UnitName 'NonMetric
 anyUnitName (AnyUnit _ n _) = n


### PR DESCRIPTION
`Data.Semigroup` was added to `base` in 4.9, which is the minimum `base` version that is supported, so the `semigroups` dependency is redundant.