### PR TITLE
Add doc comments for SI prefixes & rename "deka" to "deca"

### DIFF
--- a/src/Numeric/Units/Dimensional/NonSI.hs
+++ b/src/Numeric/Units/Dimensional/NonSI.hs
@@ -99,7 +99,7 @@ import qualified Prelude
 From Table 7, units accepted for use with the SI whose values in SI units are
 obtained experimentally.
 
-When <#note1 [1]> was published the electron volt had a standard combined
+When <#note1 [1]> was published, the electron volt had a standard combined
 uncertainity of 0.00000049e-19 J and the unified atomic mass unit
 had a combined uncertainty of 0.0000010e-27 kg.
 
@@ -119,7 +119,7 @@ dalton = mkUnitR (ucumMetric "u" "Da" "Dalton") 1 $ unifiedAtomicMassUnit
 
 -- | One percent is one hundrendth.
 --
--- The dimensionless number 0.01 , represented by the symbol %, is commonly used as a dimensionless unit.
+-- The dimensionless number 0.01, represented by the symbol %, is commonly used as a dimensionless unit.
 --
 -- See section 7.10.2 of the <#note1 [1]> for further information.
 --
@@ -468,7 +468,7 @@ nauticalMile = mkUnitZ (ucum "[nmi_i]" "NM" "nautical mile") 1852 $ meter
 knot :: (Fractional a) => Unit 'NonMetric DVelocity a
 knot = mkUnitQ (ucum "[kt_i]" "kt" "knot") 1 $ nauticalMile / hour
 
--- | One revolution is an angle equal to 2 pi radians; a full circle.
+-- | One revolution is an angle equal to 2*pi radians; a full circle.
 --
 -- See <https://en.wikipedia.org/wiki/Turn_%28geometry%29 here> for further information.
 --

--- a/src/Numeric/Units/Dimensional/SIUnits.hs
+++ b/src/Numeric/Units/Dimensional/SIUnits.hs
@@ -92,7 +92,7 @@ deca, deka, hecto, kilo, mega, giga, tera, peta, exa, zetta, yotta
   :: Num a => Unit 'Metric d a -> Unit 'NonMetric d a
 -- | The "deca" prefix, denoting a factor of 10.
 deca  = applyMultiple I.deca -- International English.
--- | An alias for 'deka'.
+-- | An alias for 'deca'.
 deka  = deca      -- American English.
 -- | The "hecto" prefix, denoting a factor of 100.
 hecto = applyMultiple I.hecto

--- a/src/Numeric/Units/Dimensional/SIUnits.hs
+++ b/src/Numeric/Units/Dimensional/SIUnits.hs
@@ -73,9 +73,7 @@ import qualified Prelude
 
 {- $multiples
 Prefixes are used to form decimal multiples and submultiples of SI
-Units as described in section 4.4. We will define the SI prefixes
-in terms of the 'prefix' function which applies a scale factor to a
-unit.
+Units as described in section 4.4.
 
 By defining SI prefixes as functions applied to a 'Unit' we satisfy
 section 6.2.6 "Unacceptability of stand-alone prefixes".
@@ -90,24 +88,36 @@ applyMultiple p u | denominator x == 1 = mkUnitZ n' (numerator x) u
     n' = N.applyPrefix p (name u)
     x = N.scaleFactor p
 
-deka, deca, hecto, kilo, mega, giga, tera, peta, exa, zetta, yotta
+deca, deka, hecto, kilo, mega, giga, tera, peta, exa, zetta, yotta
   :: Num a => Unit 'Metric d a -> Unit 'NonMetric d a
-deka  = applyMultiple I.deka -- International English.
-deca  = deka      -- American English.
+-- | The "deca" prefix, denoting a factor of 10.
+deca  = applyMultiple I.deca -- International English.
+-- | An alias for 'deka'.
+deka  = deca      -- American English.
+-- | The "hecto" prefix, denoting a factor of 100.
 hecto = applyMultiple I.hecto
+-- | The "kilo" prefix, denoting a factor of 1000.
 kilo  = applyMultiple I.kilo
+-- | The "mega" prefix, denoting a factor of 10^6.
 mega  = applyMultiple I.mega
+-- | The "giga" prefix, denoting a factor of 10^9.
 giga  = applyMultiple I.giga
+-- | The "tera" prefix, denoting a factor of 10^12.
 tera  = applyMultiple I.tera
+-- | The "peta" prefix, denoting a factor of 10^15.
 peta  = applyMultiple I.peta
+-- | The "exa" prefix, denoting a factor of 10^18.
 exa   = applyMultiple I.exa
+-- | The "zetta" prefix, denoting a factor of 10^21.
 zetta = applyMultiple I.zetta
+-- | The "yotta" prefix, denoting a factor of 10^24.
 yotta = applyMultiple I.yotta
 
 {- $submultiples
 Then the submultiples.
 -}
 
+-- | Apply a 'Prefix' to a metric 'Unit'.
 applyPrefix :: (Fractional a) => Prefix -> Unit 'Metric d a -> Unit 'NonMetric d a
 applyPrefix p u = mkUnitQ n' x u
   where
@@ -116,15 +126,25 @@ applyPrefix p u = mkUnitQ n' x u
 
 deci, centi, milli, micro, nano, pico, femto, atto, zepto, yocto
   :: Fractional a => Unit 'Metric d a -> Unit 'NonMetric d a
+-- | The "deci" prefix, denoting a factor of 0.1.
 deci  = applyPrefix I.deci
+-- | The "centi" prefix, denoting a factor of 0.01.
 centi = applyPrefix I.centi
+-- | The "milli" prefix, denoting a factor of 0.001.
 milli = applyPrefix I.milli
+-- | The "micro" prefix, denoting a factor of 10^-6.
 micro = applyPrefix I.micro
+-- | The "nano" prefix, denoting a factor of 10^-9.
 nano  = applyPrefix I.nano
+-- | The "pico" prefix, denoting a factor of 10^-12.
 pico  = applyPrefix I.pico
+-- | The "femto" prefix, denoting a factor of 10^-15.
 femto = applyPrefix I.femto
+-- | The "atto" prefix, denoting a factor of 10^-18.
 atto  = applyPrefix I.atto
+-- | The "zepto" prefix, denoting a factor of 10^-21.
 zepto = applyPrefix I.zepto
+-- | The "yocto" prefix, denoting a factor of 10^-24.
 yocto = applyPrefix I.yocto
 
 {- $reified-prefixes
@@ -137,7 +157,7 @@ list of all prefixes defined by the SI.
 {- $base-units
 These are the base units from section 4.1. To avoid a
 myriad of one-letter functions that would doubtlessly cause clashes
-and frustration in users' code we spell out all unit names in full,
+and frustration in users' code, we spell out all unit names in full,
 as we did for prefixes. We also elect to spell the unit names in
 singular form, as allowed by section 9.7 "Other spelling conventions".
 

--- a/src/Numeric/Units/Dimensional/UnitNames/Internal.hs
+++ b/src/Numeric/Units/Dimensional/UnitNames/Internal.hs
@@ -79,12 +79,14 @@ instance Show (UnitName m) where
   show (Grouped n) = "(" ++ show n ++ ")"
   show (Weaken n) = show n
 
+-- | Converts a 'UnitName' to a 'NameAtom', if possible.
 asAtomic :: UnitName m -> Maybe (NameAtom ('UnitAtom m))
 asAtomic (MetricAtomic a) = Just a
 asAtomic (Atomic a) = Just a
 asAtomic (Weaken n) = coerce <$> asAtomic n
 asAtomic _ = Nothing
 
+-- | Returns 'True' if the 'UnitName' is atomic.
 isAtomic :: UnitName m -> Bool
 isAtomic One = True
 isAtomic (MetricAtomic _) = True
@@ -98,7 +100,7 @@ isAtomicOrProduct :: UnitName m -> Bool
 isAtomicOrProduct (Product _ _) = True
 isAtomicOrProduct n = isAtomic n
 
--- reduce by algebraic simplifications
+-- | Reduce a 'UnitName' by algebraic simplifications.
 reduce :: UnitName m -> UnitName m
 reduce One = One
 reduce n@(MetricAtomic _) = n
@@ -131,6 +133,7 @@ instance NFData NameAtomType where -- instance is derived from Generic instance
 -- | The name of a metric prefix.
 type PrefixName = NameAtom 'PrefixAtom
 
+-- | A metric prefix.
 data Prefix = Prefix
               {
                 -- | The name of a metric prefix.
@@ -184,8 +187,8 @@ baseUnitName d = let powers = asList $ dimension d
 baseUnitNames :: [UnitName 'NonMetric]
 baseUnitNames = [weaken nMeter, nKilogram, weaken nSecond, weaken nAmpere, weaken nKelvin, weaken nMole, weaken nCandela]
 
-deka, hecto, kilo, mega, giga, tera, peta, exa, zetta, yotta :: Prefix
-deka  = prefix "da" "da" "deka" 1e1
+deca, hecto, kilo, mega, giga, tera, peta, exa, zetta, yotta :: Prefix
+deca  = prefix "da" "da" "deca" 1e1
 hecto = prefix "h" "h" "hecto"  1e2
 kilo  = prefix "k" "k" "kilo"   1e3
 mega  = prefix "M" "M" "mega"   1e6
@@ -209,7 +212,7 @@ yocto = prefix "y" "y" "yocto"  1e-24
 
 -- | A list of all 'Prefix'es defined by the SI.
 siPrefixes :: [Prefix]
-siPrefixes = [yocto, zepto, atto, femto, pico, nano, micro, milli, centi, deci, deka, hecto, kilo, mega, giga, tera, peta, exa, zetta, yotta]
+siPrefixes = [yocto, zepto, atto, femto, pico, nano, micro, milli, centi, deci, deca, hecto, kilo, mega, giga, tera, peta, exa, zetta, yotta]
 
 -- | Forms a 'UnitName' from a 'Metric' name by applying a metric prefix.
 applyPrefix :: Prefix -> UnitName 'Metric -> UnitName 'NonMetric


### PR DESCRIPTION
Add some missing doc comments.

As for "deca" vs "deka": According to [Wikipedia](https://en.wikipedia.org/wiki/Deca-), the international spelling is "deca", while "deka" is the american spelling (so exactly the opposite of what was claimed here). Also, the [SI Brochure](https://www.bipm.org/documents/20126/41483022/SI-Brochure-9.pdf/fcf090b2-04e6-88cc-1149-c3e029ad8232) only mentions "deca". I thus changed the `deka` `Prefix` to `deca` and changed the full name.