### PR TITLE
Better testing of optional flags in Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,9 @@ jobs:
           - "9.6.6"
           - "9.8.2"
           - "9.10.1"
-        flags:
+        constraints:
           - "" # base case
-        # Only activate after #224 has landed
-        #   - "+binary"
+          - "--constraint=\"dimensional +binary\""
 
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +34,7 @@ jobs:
     - name: Generate freeze file
       run: |
         cabal update
-        cabal configure --disable-optimization --flags="${{ matrix.flags }}" --enable-tests
+        cabal configure --disable-optimization ${{ matrix.constraints }} --enable-tests
         cabal freeze
     
     - name: Cache cabal work


### PR DESCRIPTION
Turns out that `cabal build --flags="+binary"` silently does nothing.

This is a small PR to fix #225 